### PR TITLE
add throwing error if user try to set as operator second time

### DIFF
--- a/src/modules/operator/operator.service.ts
+++ b/src/modules/operator/operator.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import * as operatorSchema from '@app/modules/operator/operator.schema';
 import { CreateOperatorDto } from './dto/create-operator.dto';
@@ -17,6 +17,14 @@ export class OperatorService {
   ) {}
 
   async addOperator(dto: CreateOperatorDto, user: User) {
+    const existingOperator = await this.db
+      .select()
+      .from(operatorSchema.operators)
+      .where(eq(operatorSchema.operators.userId, user.id));
+
+    if (existingOperator.length > 0) {
+      throw new BadRequestException('User is already registered as operator');
+    }
     const newOperator = await this.db
       .insert(operatorSchema.operators)
       .values({
@@ -29,6 +37,7 @@ export class OperatorService {
         userId: user.id,
       })
       .returning();
+    await this.userService.userToOperator(user.id);
     return newOperator[0];
   }
 

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { JWTPayload } from '@app/types/jwt.payload';
 import * as userSchema from '@app/modules/user/user.schema';
@@ -35,7 +35,7 @@ export class UserService {
       where: (users, { eq }) => eq(users.id, userId),
     });
     if (!user) {
-      throw new Error('User not found');
+      throw new NotFoundException('User not found');
     }
     return await this.db
       .update(userSchema.users)

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -3,6 +3,7 @@ import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { JWTPayload } from '@app/types/jwt.payload';
 import * as userSchema from '@app/modules/user/user.schema';
 import { mapToUserEntity } from '@app/types/user_mapper';
+import { eq } from 'drizzle-orm';
 
 @Injectable()
 export class UserService {
@@ -27,5 +28,18 @@ export class UserService {
       return newUser[0];
     }
     return userInDb;
+  }
+
+  async userToOperator(userId: number) {
+    const user = await this.db.query.users.findFirst({
+      where: (users, { eq }) => eq(users.id, userId),
+    });
+    if (!user) {
+      throw new Error('User not found');
+    }
+    return await this.db
+      .update(userSchema.users)
+      .set({ role: 'operator' })
+      .where(eq(userSchema.users.id, userId));
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator signup now enforces one operator per user; duplicate attempts return a clear validation error.
  * After successful operator signup, the linked user account is automatically upgraded to the Operator role so permissions apply immediately.
  * Improved data integrity and clearer user-facing feedback during the signup flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->