### PR TITLE
Fixed countries dto

### DIFF
--- a/src/modules/cities/cities.service.ts
+++ b/src/modules/cities/cities.service.ts
@@ -32,7 +32,7 @@ export class CitiesService {
           city.name.toLowerCase().startsWith(q.toLowerCase()),
         );
       } catch (error) {
-        console.error(error);
+        console.error('Error filtering cities:', error);
       }
     }
     return allCities;

--- a/src/modules/countries/countries.controller.ts
+++ b/src/modules/countries/countries.controller.ts
@@ -8,6 +8,9 @@ export class CountriesController {
 
   @Get()
   async getCountries(@Query() query: GetCountriesDto) {
-    return this.countriesService.getCountries(query.lang || 'en');
+    return this.countriesService.getCountries(
+      query.lang || 'en',
+      query.q || '',
+    );
   }
 }

--- a/src/modules/countries/countries.service.ts
+++ b/src/modules/countries/countries.service.ts
@@ -10,9 +10,9 @@ export class CountriesService {
     @Inject('DRIZZLE_CLIENT')
     private db: NodePgDatabase<typeof schema>, // <-- Типізуйте db згідно з вашою основною схемою
   ) {}
-  async getCountries(lang: string) {
+  async getCountries(lang: string, q: string = '') {
     const { countries, countryTranslations } = schema;
-    return await this.db
+    const allCountries = this.db
       .select({
         iso2: countries.iso2,
         name: countryTranslations.name,
@@ -23,5 +23,17 @@ export class CountriesService {
         eq(countryTranslations.countryIso2, countries.iso2),
       )
       .where(eq(countryTranslations.languageCode, lang));
+
+    if (q) {
+      try {
+        return (await allCountries).filter((country) =>
+          country.name.toLowerCase().startsWith(q.toLowerCase()),
+        );
+      } catch (error) {
+        console.error('Error filtering countries:', error);
+      }
+    }
+
+    return await allCountries;
   }
 }

--- a/src/modules/countries/countries.service.ts
+++ b/src/modules/countries/countries.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import * as schema from '@app/db/schema/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq, ilike } from 'drizzle-orm';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 
 @Injectable()
@@ -12,6 +12,14 @@ export class CountriesService {
   ) {}
   async getCountries(lang: string, q: string = '') {
     const { countries, countryTranslations } = schema;
+    const baseWhere = and(
+      eq(countryTranslations.countryIso2, countries.iso2),
+      eq(countryTranslations.languageCode, lang),
+    );
+    const whereClause = q?.trim()
+      ? and(baseWhere, ilike(countryTranslations.name, `${q.trim()}%`))
+      : baseWhere;
+
     const allCountries = this.db
       .select({
         iso2: countries.iso2,
@@ -22,17 +30,7 @@ export class CountriesService {
         countryTranslations,
         eq(countryTranslations.countryIso2, countries.iso2),
       )
-      .where(eq(countryTranslations.languageCode, lang));
-
-    if (q) {
-      try {
-        return (await allCountries).filter((country) =>
-          country.name.toLowerCase().startsWith(q.toLowerCase()),
-        );
-      } catch (error) {
-        console.error('Error filtering countries:', error);
-      }
-    }
+      .where(whereClause);
 
     return await allCountries;
   }

--- a/src/modules/countries/dto/get-country.dto.ts
+++ b/src/modules/countries/dto/get-country.dto.ts
@@ -1,8 +1,25 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsOptional, IsString, Length } from 'class-validator';
 
 export class GetCountriesDto {
+  @ApiPropertyOptional({
+    example: 'en',
+    description: 'Language for country names',
+    maxLength: 2,
+    enum: ['uk', 'en'],
+    default: 'en',
+  })
   @IsString()
   @IsOptional()
-  @Length(2, 5) // приклад: "en", "uk", "de-DE"
+  @Length(2, 2, { message: 'lang must be exactly 2 characters.' })
   lang?: string = 'en';
+
+  @ApiPropertyOptional({
+    example: null,
+    description: 'Search query to filter countries by name',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  q?: string;
 }


### PR DESCRIPTION
fixed dto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Countries endpoint supports optional q query parameter to filter by name prefix.
* **Bug Fixes**
  * lang validation now requires exactly 2 characters (e.g., "en", "uk").
* **Documentation**
  * API docs updated to document q and provide clearer lang examples/details.
* **Chores**
  * Improved error logging around city filtering to aid diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->