### PR TITLE
Feature/tour photos add is main description

### DIFF
--- a/drizzle/0003_awesome_wallflower.sql
+++ b/drizzle/0003_awesome_wallflower.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "tour_photos" ADD COLUMN "is_main" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "tour_photos" ADD COLUMN "description" text;

--- a/drizzle/0004_add_main_photo_constraint.sql
+++ b/drizzle/0004_add_main_photo_constraint.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "main_photo_idx" ON "tour_photos" ("tour_id") WHERE "is_main" = true;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,890 @@
+{
+  "id": "6e6dc2f7-aab1-4ae0-9da7-46eedd02ca81",
+  "prevId": "15dc6c11-cb7a-48fc-9170-622be4fd0ad3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tour_id": {
+          "name": "tour_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_payment'"
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "payment_provider": {
+          "name": "payment_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_session_id": {
+          "name": "payment_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bookings_user_id_users_id_fk": {
+          "name": "bookings_user_id_users_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookings_tour_id_tours_id_fk": {
+          "name": "bookings_tour_id_tours_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "tours",
+          "columnsFrom": [
+            "tour_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cities": {
+      "name": "cities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "country_iso2": {
+          "name": "country_iso2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cities_country_iso2_countries_iso2_fk": {
+          "name": "cities_country_iso2_countries_iso2_fk",
+          "tableFrom": "cities",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_iso2"
+          ],
+          "columnsTo": [
+            "iso2"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.city_translations": {
+      "name": "city_translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "city_translations_city_id_cities_id_fk": {
+          "name": "city_translations_city_id_cities_id_fk",
+          "tableFrom": "city_translations",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "city_translations_city_id_language_code_unique": {
+          "name": "city_translations_city_id_language_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "city_id",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.countries": {
+      "name": "countries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iso2": {
+          "name": "iso2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iso3": {
+          "name": "iso3",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "countries_iso2_unique": {
+          "name": "countries_iso2_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iso2"
+          ]
+        },
+        "countries_iso3_unique": {
+          "name": "countries_iso3_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iso3"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.country_translations": {
+      "name": "country_translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "country_iso2": {
+          "name": "country_iso2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "country_translations_country_iso2_countries_iso2_fk": {
+          "name": "country_translations_country_iso2_countries_iso2_fk",
+          "tableFrom": "country_translations",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_iso2"
+          ],
+          "columnsTo": [
+            "iso2"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "country_translations_country_iso2_language_code_unique": {
+          "name": "country_translations_country_iso2_language_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "country_iso2",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health": {
+      "name": "health",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "health_email_unique": {
+          "name": "health_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "philosophy": {
+          "name": "philosophy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo": {
+          "name": "photo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "operators_user_id_users_id_fk": {
+          "name": "operators_user_id_users_id_fk",
+          "tableFrom": "operators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "operators_email_unique": {
+          "name": "operators_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "operators_user_id_unique": {
+          "name": "operators_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tour_photos": {
+      "name": "tour_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tour_id": {
+          "name": "tour_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tour_photos_tour_id_tours_id_fk": {
+          "name": "tour_photos_tour_id_tours_id_fk",
+          "tableFrom": "tour_photos",
+          "tableTo": "tours",
+          "columnsFrom": [
+            "tour_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tour_photos_url_unique": {
+          "name": "tour_photos_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tours": {
+      "name": "tours",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_iso2_code": {
+          "name": "country_iso2_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UAH'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_spots": {
+          "name": "available_spots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "adults": {
+          "name": "adults",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "children": {
+          "name": "children",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pets_allowed": {
+          "name": "pets_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "departure_city_id": {
+          "name": "departure_city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departure_country_iso2_code": {
+          "name": "departure_country_iso2_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tours_operator_id_operators_id_fk": {
+          "name": "tours_operator_id_operators_id_fk",
+          "tableFrom": "tours",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "tours_country_iso2_code_countries_iso2_fk": {
+          "name": "tours_country_iso2_code_countries_iso2_fk",
+          "tableFrom": "tours",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_iso2_code"
+          ],
+          "columnsTo": [
+            "iso2"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "tours_city_id_cities_id_fk": {
+          "name": "tours_city_id_cities_id_fk",
+          "tableFrom": "tours",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "tours_departure_city_id_cities_id_fk": {
+          "name": "tours_departure_city_id_cities_id_fk",
+          "tableFrom": "tours",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "departure_city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "tours_departure_country_iso2_code_countries_iso2_fk": {
+          "name": "tours_departure_country_iso2_code_countries_iso2_fk",
+          "tableFrom": "tours",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "departure_country_iso2_code"
+          ],
+          "columnsTo": [
+            "iso2"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_person_name": {
+          "name": "first_person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_person_surname": {
+          "name": "first_person_surname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_person_name": {
+          "name": "second_person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_person_surname": {
+          "name": "second_person_surname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'traveler'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_sub_unique": {
+          "name": "users_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "15dc6c11-cb7a-48fc-9170-622be4fd0ad3",
-  "prevId": "529946bd-3e71-4548-a0e8-da40eda5d54f",
+  "id": "d140ea33-1f54-4bcd-a94a-1ba6ce80ecc3",
+  "prevId": "15dc6c11-cb7a-48fc-9170-622be4fd0ad3",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -515,9 +515,39 @@
           "type": "varchar(255)",
           "primaryKey": false,
           "notNull": true
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         }
       },
-      "indexes": {},
+      "indexes": {
+        "main_photo_idx": {
+          "name": "main_photo_idx",
+          "columns": [
+            {
+              "expression": "tour_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"is_main\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "tour_photos_tour_id_tours_id_fk": {
           "name": "tour_photos_tour_id_tours_id_fk",
@@ -534,15 +564,7 @@
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "tour_photos_url_unique": {
-          "name": "tour_photos_url_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "url"
-          ]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,877 @@
+{
+  "id": "15dc6c11-cb7a-48fc-9170-622be4fd0ad3",
+  "prevId": "529946bd-3e71-4548-a0e8-da40eda5d54f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tour_id": {
+          "name": "tour_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_payment'"
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "payment_provider": {
+          "name": "payment_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_session_id": {
+          "name": "payment_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bookings_user_id_users_id_fk": {
+          "name": "bookings_user_id_users_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookings_tour_id_tours_id_fk": {
+          "name": "bookings_tour_id_tours_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "tours",
+          "columnsFrom": [
+            "tour_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cities": {
+      "name": "cities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "country_iso2": {
+          "name": "country_iso2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cities_country_iso2_countries_iso2_fk": {
+          "name": "cities_country_iso2_countries_iso2_fk",
+          "tableFrom": "cities",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_iso2"
+          ],
+          "columnsTo": [
+            "iso2"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.city_translations": {
+      "name": "city_translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "city_translations_city_id_cities_id_fk": {
+          "name": "city_translations_city_id_cities_id_fk",
+          "tableFrom": "city_translations",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "city_translations_city_id_language_code_unique": {
+          "name": "city_translations_city_id_language_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "city_id",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.countries": {
+      "name": "countries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iso2": {
+          "name": "iso2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iso3": {
+          "name": "iso3",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "countries_iso2_unique": {
+          "name": "countries_iso2_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iso2"
+          ]
+        },
+        "countries_iso3_unique": {
+          "name": "countries_iso3_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iso3"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.country_translations": {
+      "name": "country_translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "country_iso2": {
+          "name": "country_iso2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "country_translations_country_iso2_countries_iso2_fk": {
+          "name": "country_translations_country_iso2_countries_iso2_fk",
+          "tableFrom": "country_translations",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_iso2"
+          ],
+          "columnsTo": [
+            "iso2"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "country_translations_country_iso2_language_code_unique": {
+          "name": "country_translations_country_iso2_language_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "country_iso2",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health": {
+      "name": "health",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "health_email_unique": {
+          "name": "health_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "philosophy": {
+          "name": "philosophy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo": {
+          "name": "photo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "operators_user_id_users_id_fk": {
+          "name": "operators_user_id_users_id_fk",
+          "tableFrom": "operators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "operators_email_unique": {
+          "name": "operators_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "operators_user_id_unique": {
+          "name": "operators_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tour_photos": {
+      "name": "tour_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tour_id": {
+          "name": "tour_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tour_photos_tour_id_tours_id_fk": {
+          "name": "tour_photos_tour_id_tours_id_fk",
+          "tableFrom": "tour_photos",
+          "tableTo": "tours",
+          "columnsFrom": [
+            "tour_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tour_photos_url_unique": {
+          "name": "tour_photos_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tours": {
+      "name": "tours",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_iso2_code": {
+          "name": "country_iso2_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UAH'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_spots": {
+          "name": "available_spots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "adults": {
+          "name": "adults",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "children": {
+          "name": "children",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pets_allowed": {
+          "name": "pets_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "departure_city_id": {
+          "name": "departure_city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "departure_country_iso2_code": {
+          "name": "departure_country_iso2_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tours_operator_id_operators_id_fk": {
+          "name": "tours_operator_id_operators_id_fk",
+          "tableFrom": "tours",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "tours_country_iso2_code_countries_iso2_fk": {
+          "name": "tours_country_iso2_code_countries_iso2_fk",
+          "tableFrom": "tours",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_iso2_code"
+          ],
+          "columnsTo": [
+            "iso2"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "tours_city_id_cities_id_fk": {
+          "name": "tours_city_id_cities_id_fk",
+          "tableFrom": "tours",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "tours_departure_city_id_cities_id_fk": {
+          "name": "tours_departure_city_id_cities_id_fk",
+          "tableFrom": "tours",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "departure_city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "tours_departure_country_iso2_code_countries_iso2_fk": {
+          "name": "tours_departure_country_iso2_code_countries_iso2_fk",
+          "tableFrom": "tours",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "departure_country_iso2_code"
+          ],
+          "columnsTo": [
+            "iso2"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_person_name": {
+          "name": "first_person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_person_surname": {
+          "name": "first_person_surname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_person_name": {
+          "name": "second_person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_person_surname": {
+          "name": "second_person_surname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'traveler'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_sub_unique": {
+          "name": "users_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1757572383355,
       "tag": "0002_third_plazm",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1757836341688,
+      "tag": "0003_awesome_wallflower",
+      "breakpoints": true
     }
   ]
 }

--- a/src/common/validators/boolean-validator.ts
+++ b/src/common/validators/boolean-validator.ts
@@ -1,31 +1,38 @@
 import {
   registerDecorator,
+  ValidationArguments,
   ValidationOptions,
   ValidatorConstraint,
   ValidatorConstraintInterface,
 } from 'class-validator';
 
 @ValidatorConstraint({ async: false })
-export class IsBooleanStringConstraint implements ValidatorConstraintInterface {
-  validate(value: any) {
-    return (
-      value === true || value === false || value === 'true' || value === 'false'
-    );
+export class IsBooleanLikeConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown) {
+    let v: boolean | string;
+    if (typeof value === 'string') {
+      v = value.trim().toLowerCase();
+    } else if (typeof value === 'boolean') {
+      v = value;
+    } else {
+      return false;
+    }
+    return v === true || v === false || v === 'true' || v === 'false';
   }
-
-  defaultMessage() {
-    return 'isMain must be a boolean value (true or false)';
+  defaultMessage(args?: ValidationArguments) {
+    const prop = args?.property ?? 'value';
+    return `${prop} must be a boolean (true/false).`;
   }
 }
 
-export function IsBooleanString(validationOptions?: ValidationOptions) {
+export function IsBooleanLike(validationOptions?: ValidationOptions) {
   return function (object: object, propertyName: string) {
     registerDecorator({
       target: object.constructor,
       propertyName: propertyName,
       options: validationOptions,
       constraints: [],
-      validator: IsBooleanStringConstraint,
+      validator: IsBooleanLikeConstraint,
     });
   };
 }

--- a/src/common/validators/boolean-validator.ts
+++ b/src/common/validators/boolean-validator.ts
@@ -1,0 +1,31 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+@ValidatorConstraint({ async: false })
+export class IsBooleanStringConstraint implements ValidatorConstraintInterface {
+  validate(value: any) {
+    return (
+      value === true || value === false || value === 'true' || value === 'false'
+    );
+  }
+
+  defaultMessage() {
+    return 'isMain must be a boolean value (true or false)';
+  }
+}
+
+export function IsBooleanString(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsBooleanStringConstraint,
+    });
+  };
+}

--- a/src/common/validators/index.ts
+++ b/src/common/validators/index.ts
@@ -1,0 +1,1 @@
+export * from './boolean-validator';

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,10 @@ async function bootstrap() {
     .setDescription('Booking CRM API description')
     .setVersion('1.0')
     .addTag('Booking CRM')
-    .addBearerAuth()
+    .addSecurity('bearer', {
+      type: 'http',
+      scheme: 'bearer',
+    })
     .build();
   const documentFactory = () => SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, documentFactory);
@@ -29,7 +32,7 @@ async function bootstrap() {
       forbidNonWhitelisted: true,
       transform: true,
       transformOptions: {
-        enableImplicitConversion: true,
+        // enableImplicitConversion: true, // Ця опція викликає проблеми з multipart/form-data
       },
     }),
   );

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,9 @@ async function bootstrap() {
       whitelist: true,
       forbidNonWhitelisted: true,
       transform: true,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
     }),
   );
   app.use(

--- a/src/modules/tours/dto/create-tour.dto.ts
+++ b/src/modules/tours/dto/create-tour.dto.ts
@@ -15,10 +15,8 @@ import {
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBooleanString } from '@app/common/validators';
 export class TourPhotoDto {
-  @ApiPropertyOptional({
-    description: 'URL of the photo (if already uploaded)',
-  })
   @IsUrl({}, { message: 'URL must be a valid URL address.' })
   @IsOptional()
   url?: string;
@@ -26,17 +24,15 @@ export class TourPhotoDto {
   @ApiPropertyOptional({
     description: 'Is this the main photo for the tour?',
     default: false,
-    type: Boolean,
   })
   @Transform(({ value }) => {
-    if (value === 'true') return true;
-    if (value === 'false') return false;
-    if (value === true) return true;
-    if (value === false) return false;
-    return undefined; // Для @IsOptional()
+    if (value === 'true' || value === true) return true;
+    if (value === 'false' || value === false) return false;
+    return value as boolean | undefined; // залишаємо як є для валідації
   })
-  @IsBoolean({ message: 'isMain must be a boolean value' })
+  @IsBooleanString()
   @IsOptional()
+  @Allow()
   isMain?: boolean;
 
   @ApiPropertyOptional({
@@ -44,6 +40,7 @@ export class TourPhotoDto {
   })
   @IsString()
   @IsOptional()
+  @Allow()
   description?: string;
 }
 export class CreateTourDto {
@@ -195,6 +192,7 @@ export class CreateTourDto {
           const index = parseInt(match[1]);
           const photo = objValue[key];
           if (photo && typeof photo === 'object') {
+            console.log(`Photo at index ${index}:`, photo);
             result[index] = photo as TourPhotoDto;
           }
         }
@@ -237,9 +235,8 @@ export class CreateTourDto {
   })
   @IsNumber()
   @IsOptional()
-  @Min(1)
   @Type(() => Number)
-  adults?: number = 1;
+  adults?: number;
 
   @ApiProperty({
     description: 'Number of children in the tour (e.g., 1)',
@@ -273,7 +270,6 @@ export class CreateTourDto {
   @Type(() => Number)
   @IsNumber()
   @IsOptional()
-  @Min(1)
   departureCityId?: number;
 
   @ApiPropertyOptional({

--- a/src/modules/tours/dto/create-tour.dto.ts
+++ b/src/modules/tours/dto/create-tour.dto.ts
@@ -13,14 +13,10 @@ import {
   IsISO31661Alpha2,
   Allow,
 } from 'class-validator';
-import { Transform, Type } from 'class-transformer';
+import { plainToInstance, Transform, Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsBooleanString } from '@app/common/validators';
-export class TourPhotoDto {
-  @IsUrl({}, { message: 'URL must be a valid URL address.' })
-  @IsOptional()
-  url?: string;
-
+export class CreateTourPhotoDto {
   @ApiPropertyOptional({
     description: 'Is this the main photo for the tour?',
     default: false,
@@ -28,11 +24,10 @@ export class TourPhotoDto {
   @Transform(({ value }) => {
     if (value === 'true' || value === true) return true;
     if (value === 'false' || value === false) return false;
-    return value as boolean | undefined; // залишаємо як є для валідації
+    return value as boolean | undefined;
   })
   @IsBooleanString()
   @IsOptional()
-  @Allow()
   isMain?: boolean;
 
   @ApiPropertyOptional({
@@ -40,8 +35,16 @@ export class TourPhotoDto {
   })
   @IsString()
   @IsOptional()
-  @Allow()
   description?: string;
+}
+
+export class TourPhotoDto extends CreateTourPhotoDto {
+  @ApiPropertyOptional({
+    description: 'URL of the photo (if already uploaded)',
+  })
+  @IsUrl({}, { message: 'URL must be a valid URL address.' })
+  @IsOptional()
+  url?: string;
 }
 export class CreateTourDto {
   @ApiProperty({
@@ -166,46 +169,40 @@ export class CreateTourDto {
   @IsOptional()
   conditions?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description:
       'Metadata for tour photos. The order should correspond to the uploaded files. Example: photos[0][isMain]=true&photos[0][description]=Main photo',
-    type: [TourPhotoDto],
+    type: [CreateTourPhotoDto],
   })
-  @IsArray({ message: 'Photos must be an array.' })
-  @ValidateNested({ each: true })
   @Transform(({ value }) => {
-    if (!value) return [];
+    if (!value) {
+      return []; // Return empty array if no value
+    }
+    // If the client sends a JSON string in the 'photos' field
     if (typeof value === 'string') {
       try {
-        return JSON.parse(value) as TourPhotoDto[];
+        const parsed = JSON.parse(value) as unknown;
+        return plainToInstance(
+          CreateTourPhotoDto,
+          parsed as Record<string, unknown>[],
+        );
       } catch {
-        return [];
+        return value; // Let validator handle invalid string
       }
     }
-
+    // For multipart/form-data, value might be an object like { '0': {..}, '1': {..} }
     if (typeof value === 'object' && !Array.isArray(value)) {
-      const objValue = value as Record<string, unknown>;
-      const result: { [index: number]: TourPhotoDto } = {};
-      Object.keys(objValue).forEach((key) => {
-        const match = key.match(/^(\d+)$/);
-        if (match) {
-          const index = parseInt(match[1]);
-          const photo = objValue[key];
-          if (photo && typeof photo === 'object') {
-            console.log(`Photo at index ${index}:`, photo);
-            result[index] = photo as TourPhotoDto;
-          }
-        }
-      });
-
-      console.log('Transformed photos:', result);
-      return result;
+      const plainObjects = Object.values(value as { [key: string]: unknown });
+      return plainToInstance(CreateTourPhotoDto, plainObjects);
     }
-
-    return value as TourPhotoDto[];
+    // If it's already an array, just return it
+    return value as CreateTourPhotoDto[];
   })
-  @Type(() => TourPhotoDto)
-  photos: TourPhotoDto[];
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateTourPhotoDto)
+  @IsOptional()
+  photos: CreateTourPhotoDto[];
 
   @ApiProperty({
     description: 'Array of photos (1–10 files, JPG/PNG, max 5MB each)',
@@ -267,18 +264,22 @@ export class CreateTourDto {
     required: false,
     default: '',
   })
-  @Type(() => Number)
+  @Transform(({ value }) => (!value ? undefined : Number(value)))
   @IsNumber()
   @IsOptional()
+  @Min(1)
   departureCityId?: number;
 
   @ApiPropertyOptional({
     description: 'ISO2 код країни відправлення туру ',
     default: '',
   })
-  @Transform(({ value }): string | undefined =>
-    typeof value === 'string' ? value.toUpperCase() : value,
-  )
+  @Transform(({ value }) => {
+    if (typeof value === 'string' && value.trim() !== '') {
+      return value.toUpperCase();
+    }
+    return undefined;
+  })
   @IsISO31661Alpha2({
     message:
       'departureCountryISO2Code must be a valid ISO 3166-1 alpha-2 code.',

--- a/src/modules/tours/dto/create-tour.dto.ts
+++ b/src/modules/tours/dto/create-tour.dto.ts
@@ -15,7 +15,7 @@ import {
 } from 'class-validator';
 import { plainToInstance, Transform, Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsBooleanString } from '@app/common/validators';
+import { IsBooleanLike } from '@app/common/validators';
 export class CreateTourPhotoDto {
   @ApiPropertyOptional({
     description: 'Is this the main photo for the tour?',
@@ -26,7 +26,7 @@ export class CreateTourPhotoDto {
     if (value === 'false' || value === false) return false;
     return value as boolean | undefined;
   })
-  @IsBooleanString()
+  @IsBooleanLike()
   @IsOptional()
   isMain?: boolean;
 
@@ -174,33 +174,44 @@ export class CreateTourDto {
       'Metadata for tour photos. The order should correspond to the uploaded files. Example: photos[0][isMain]=true&photos[0][description]=Main photo',
     type: [CreateTourPhotoDto],
   })
+  // Трансформація для поля photos, щоб коректно обробляти різні формати вхідних даних (JSON-рядок, об'єкт, масив)
+  // та забезпечити, що на вхід валідатора завжди надходитиме масив об'єктів CreateTourPhotoDto.
   @Transform(({ value }) => {
     if (!value) {
-      return []; // Return empty array if no value
+      return []; // Повертаємо пустий масив, якщо дані відсутні
     }
-    // If the client sends a JSON string in the 'photos' field
-    if (typeof value === 'string') {
+
+    let photoData: unknown = value;
+    // Якщо дані прийшли як JSON-рядок, розпарсюємо його
+    if (typeof photoData === 'string') {
       try {
-        const parsed = JSON.parse(value) as unknown;
-        return plainToInstance(
-          CreateTourPhotoDto,
-          parsed as Record<string, unknown>[],
-        );
-      } catch {
-        return value; // Let validator handle invalid string
+        photoData = JSON.parse(photoData);
+      } catch (e) {
+        console.error(e);
+        return value as unknown; // У разі помилки парсингу повертаємо оригінальне значення, щоб валідатор видав помилку
       }
     }
-    // For multipart/form-data, value might be an object like { '0': {..}, '1': {..} }
-    if (typeof value === 'object' && !Array.isArray(value)) {
-      const plainObjects = Object.values(value as { [key: string]: unknown });
-      return plainToInstance(CreateTourPhotoDto, plainObjects);
+
+    // Якщо дані є об'єктом (але не масивом), це може бути як один об'єкт фото,
+    // так і об'єкт з індексами {'0': {...}, '1': {...}} з multipart/form-data.
+    if (typeof photoData === 'object' && !Array.isArray(photoData)) {
+      const keys = Object.keys(photoData);
+      // Перевіряємо, чи є ключі числовими індексами
+      const isArrayLike = keys.length > 0 && keys.every((k) => /^\d+$/.test(k));
+      if (isArrayLike) {
+        photoData = Object.values(photoData); // Перетворюємо в масив значень
+      }
     }
-    // If it's already an array, just return it
-    return value as CreateTourPhotoDto[];
+
+    // Переконуємося, що дані є масивом. Якщо ні - загортаємо в масив.
+    const photosArray = Array.isArray(photoData) ? photoData : [photoData];
+
+    // Перетворюємо масив простих об'єктів на масив екземплярів CreateTourPhotoDto
+    return plainToInstance(CreateTourPhotoDto, photosArray);
   })
-  @IsArray()
   @ValidateNested({ each: true })
   @Type(() => CreateTourPhotoDto)
+  @IsArray({ message: 'Photos must be an array.' })
   @IsOptional()
   photos: CreateTourPhotoDto[];
 
@@ -274,11 +285,10 @@ export class CreateTourDto {
     description: 'ISO2 код країни відправлення туру ',
     default: '',
   })
-  @Transform(({ value }) => {
-    if (typeof value === 'string' && value.trim() !== '') {
-      return value.toUpperCase();
-    }
-    return undefined;
+  @Transform(({ value }): string | undefined => {
+    if (typeof value !== 'string') return undefined;
+    const v = value.trim();
+    return v ? v.toUpperCase() : undefined;
   })
   @IsISO31661Alpha2({
     message:

--- a/src/modules/tours/dto/create-tour.dto.ts
+++ b/src/modules/tours/dto/create-tour.dto.ts
@@ -7,21 +7,45 @@ import {
   IsBoolean,
   IsOptional,
   IsArray,
-  ArrayMinSize,
   ValidateNested,
   IsUrl,
   MaxLength,
   IsISO31661Alpha2,
+  Allow,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-
 export class TourPhotoDto {
+  @ApiPropertyOptional({
+    description: 'URL of the photo (if already uploaded)',
+  })
   @IsUrl({}, { message: 'URL must be a valid URL address.' })
-  @IsNotEmpty({ message: 'URL cannot be empty.' })
-  url: string;
-}
+  @IsOptional()
+  url?: string;
 
+  @ApiPropertyOptional({
+    description: 'Is this the main photo for the tour?',
+    default: false,
+    type: Boolean,
+  })
+  @Transform(({ value }) => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    if (value === true) return true;
+    if (value === false) return false;
+    return undefined; // Для @IsOptional()
+  })
+  @IsBoolean({ message: 'isMain must be a boolean value' })
+  @IsOptional()
+  isMain?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Description of the photo',
+  })
+  @IsString()
+  @IsOptional()
+  description?: string;
+}
 export class CreateTourDto {
   @ApiProperty({
     description: 'Title of the tour (e.g. "Weekend Getaway to Paris")',
@@ -146,23 +170,54 @@ export class CreateTourDto {
   conditions?: string;
 
   @ApiProperty({
-    description: 'Array of image files to upload for the tour.',
-    type: 'array',
-    items: {
-      type: 'string',
-      format: 'binary',
-    },
-    required: true,
-    default: true,
+    description:
+      'Metadata for tour photos. The order should correspond to the uploaded files. Example: photos[0][isMain]=true&photos[0][description]=Main photo',
+    type: [TourPhotoDto],
   })
   @IsArray({ message: 'Photos must be an array.' })
-  @ArrayMinSize(1, {
-    message: 'At least one photo URL is required for a tour.',
-  })
   @ValidateNested({ each: true })
+  @Transform(({ value }) => {
+    if (!value) return [];
+    if (typeof value === 'string') {
+      try {
+        return JSON.parse(value) as TourPhotoDto[];
+      } catch {
+        return [];
+      }
+    }
+
+    if (typeof value === 'object' && !Array.isArray(value)) {
+      const objValue = value as Record<string, unknown>;
+      const result: { [index: number]: TourPhotoDto } = {};
+      Object.keys(objValue).forEach((key) => {
+        const match = key.match(/^(\d+)$/);
+        if (match) {
+          const index = parseInt(match[1]);
+          const photo = objValue[key];
+          if (photo && typeof photo === 'object') {
+            result[index] = photo as TourPhotoDto;
+          }
+        }
+      });
+
+      console.log('Transformed photos:', result);
+      return result;
+    }
+
+    return value as TourPhotoDto[];
+  })
   @Type(() => TourPhotoDto)
-  @IsOptional()
   photos: TourPhotoDto[];
+
+  @ApiProperty({
+    description: 'Array of photos (1–10 files, JPG/PNG, max 5MB each)',
+    type: 'array',
+    items: { type: 'string', format: 'binary' },
+    minItems: 1,
+    maxItems: 10,
+  })
+  @Allow()
+  photo_files: Express.Multer.File[];
 
   @ApiPropertyOptional({
     description: 'Is the tour currently active and available for booking?',

--- a/src/modules/tours/pipes/index.ts
+++ b/src/modules/tours/pipes/index.ts
@@ -1,0 +1,1 @@
+export * from './photo-validation.pipe';

--- a/src/modules/tours/pipes/photo-validation.pipe.ts
+++ b/src/modules/tours/pipes/photo-validation.pipe.ts
@@ -1,0 +1,31 @@
+// src/modules/photos/pipes/photo-validation.pipe.ts
+import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
+
+@Injectable()
+export class PhotoValidationPipe implements PipeTransform {
+  transform(files: Express.Multer.File[]) {
+    if (!files || files.length === 0) {
+      throw new BadRequestException('At least 1 photo is required.');
+    }
+
+    if (files.length > 10) {
+      throw new BadRequestException('No more than 10 photos are allowed.');
+    }
+
+    files.forEach((file, index) => {
+      if (!file.mimetype.match(/\/(jpg|jpeg|png)$/)) {
+        throw new BadRequestException(
+          `File ${index + 1}: Only JPG/PNG files are allowed`,
+        );
+      }
+
+      if (file.size > 5 * 1024 * 1024) {
+        throw new BadRequestException(
+          `File ${index + 1}: File size exceeds 5MB`,
+        );
+      }
+    });
+
+    return files;
+  }
+}

--- a/src/modules/tours/tours.controller.ts
+++ b/src/modules/tours/tours.controller.ts
@@ -136,7 +136,8 @@ export class ToursController {
     };
   }
 
-  @Patch(':id') // Оновлення туру
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard) // Оновлення туру
   @UsePipes(
     new ValidationPipe({
       transform: true,
@@ -152,7 +153,7 @@ export class ToursController {
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateTourDto: UpdateTourDto,
-    @UploadedFiles() files: Express.Multer.File[],
+    @UploadedFiles(PhotoValidationPipe) files: Express.Multer.File[],
     @Req() req: AuthenticatedRequest,
   ) {
     try {
@@ -208,6 +209,7 @@ export class ToursController {
   }
 
   @Delete(':id')
+  @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiBearerAuth('bearer')
   async remove(

--- a/src/modules/tours/tours.controller.ts
+++ b/src/modules/tours/tours.controller.ts
@@ -27,7 +27,7 @@ import { FilesInterceptor } from '@nestjs/platform-express';
 import multer from 'multer';
 import { CloudinaryService } from '@app/cloudinary/cloudinary.service';
 import { UpdateTourDto } from './dto/update-tour.dto';
-import { ApiConsumes } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiConsumes } from '@nestjs/swagger';
 import { AuthenticatedRequest } from '@app/types/authenticated.request';
 import { JwtAuthGuard } from '@app/common/guards/jwt-auth.guard';
 import { PhotoValidationPipe } from './pipes';
@@ -38,6 +38,7 @@ export class ToursController {
     private readonly cloudinaryService: CloudinaryService,
   ) {}
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('bearer')
   @Post()
   @UsePipes(new ValidationPipe({ transform: true }))
   @UseInterceptors(
@@ -50,22 +51,6 @@ export class ToursController {
     @UploadedFiles(PhotoValidationPipe) files: Express.Multer.File[],
     @Req() req: AuthenticatedRequest,
   ): Promise<Tour> {
-    console.log('Raw body:', JSON.stringify(createTourDto, null, 2));
-    console.log('Body type:', typeof createTourDto);
-    console.log('Photos:', createTourDto.photos);
-    console.log('Photos type:', typeof createTourDto.photos);
-
-    if (createTourDto.photos) {
-      console.log(
-        'Each photo:',
-        createTourDto.photos.map((p, i) => ({
-          index: i,
-          photo: p,
-          isMainType: typeof p?.isMain,
-          isMainValue: p?.isMain,
-        })),
-      );
-    }
     try {
       const operatorId = req.user.operatorId;
       if (!operatorId) {
@@ -163,6 +148,7 @@ export class ToursController {
     FilesInterceptor('photo_files', 10, { storage: multer.memoryStorage() }),
   )
   @ApiConsumes('multipart/form-data')
+  @ApiBearerAuth('bearer')
   async update(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateTourDto: UpdateTourDto,
@@ -223,6 +209,7 @@ export class ToursController {
 
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiBearerAuth('bearer')
   async remove(
     @Param('id', ParseIntPipe) id: number,
     @Req() req: AuthenticatedRequest,

--- a/src/modules/tours/tours.controller.ts
+++ b/src/modules/tours/tours.controller.ts
@@ -30,7 +30,7 @@ import { UpdateTourDto } from './dto/update-tour.dto';
 import { ApiConsumes } from '@nestjs/swagger';
 import { AuthenticatedRequest } from '@app/types/authenticated.request';
 import { JwtAuthGuard } from '@app/common/guards/jwt-auth.guard';
-
+import { PhotoValidationPipe } from './pipes';
 @Controller('tours')
 export class ToursController {
   constructor(
@@ -41,26 +41,59 @@ export class ToursController {
   @Post()
   @UsePipes(new ValidationPipe({ transform: true }))
   @UseInterceptors(
-    FilesInterceptor('photos', 10, { storage: multer.memoryStorage() }),
+    FilesInterceptor('photo_files', 10, { storage: multer.memoryStorage() }),
   )
   @ApiConsumes('multipart/form-data')
   async create(
-    @Body() createTourDto: CreateTourDto,
-    @UploadedFiles() files: Express.Multer.File[],
+    @Body(new ValidationPipe({ transform: true, whitelist: true }))
+    createTourDto: CreateTourDto,
+    @UploadedFiles(PhotoValidationPipe) files: Express.Multer.File[],
     @Req() req: AuthenticatedRequest,
   ): Promise<Tour> {
+    console.log('Raw body:', JSON.stringify(createTourDto, null, 2));
+    console.log('Body type:', typeof createTourDto);
+    console.log('Photos:', createTourDto.photos);
+    console.log('Photos type:', typeof createTourDto.photos);
+
+    if (createTourDto.photos) {
+      console.log(
+        'Each photo:',
+        createTourDto.photos.map((p, i) => ({
+          index: i,
+          photo: p,
+          isMainType: typeof p?.isMain,
+          isMainValue: p?.isMain,
+        })),
+      );
+    }
     try {
       const operatorId = req.user.operatorId;
       if (!operatorId) {
         throw new BadRequestException('Operator ID not found.');
       }
       if (files && files.length > 0) {
+        if (
+          createTourDto.photos &&
+          createTourDto.photos.length > 0 &&
+          createTourDto.photos.length !== files.length
+        ) {
+          throw new BadRequestException(
+            'The number of files does not match the number of photo metadata entries.',
+          );
+        }
+
         const uploadedPhotos = await Promise.all(
-          files.map((file) =>
-            this.cloudinaryService.uploadImage(file.buffer).then((res) => ({
-              url: res.secure_url,
-            })),
-          ),
+          files.map(async (file, index) => {
+            const uploadResult = await this.cloudinaryService.uploadImage(
+              file.buffer,
+            );
+            const photoMeta = createTourDto.photos?.[index] ?? {};
+            return {
+              url: uploadResult.secure_url,
+              isMain: photoMeta.isMain ?? false,
+              description: photoMeta.description,
+            };
+          }),
         );
         createTourDto.photos = uploadedPhotos;
       }
@@ -127,7 +160,7 @@ export class ToursController {
     }),
   )
   @UseInterceptors(
-    FilesInterceptor('photos', 10, { storage: multer.memoryStorage() }),
+    FilesInterceptor('photo_files', 10, { storage: multer.memoryStorage() }),
   )
   @ApiConsumes('multipart/form-data')
   async update(
@@ -143,12 +176,28 @@ export class ToursController {
       }
 
       if (files && files.length > 0) {
+        if (
+          updateTourDto.photos &&
+          updateTourDto.photos.length > 0 &&
+          updateTourDto.photos.length !== files.length
+        ) {
+          throw new BadRequestException(
+            'The number of files does not match the number of photo metadata entries.',
+          );
+        }
+
         const uploadedPhotos = await Promise.all(
-          files.map((file) =>
-            this.cloudinaryService.uploadImage(file.buffer).then((res) => ({
-              url: res.secure_url,
-            })),
-          ),
+          files.map(async (file, index) => {
+            const uploadResult = await this.cloudinaryService.uploadImage(
+              file.buffer,
+            );
+            const photoMeta = updateTourDto.photos?.[index] ?? {};
+            return {
+              url: uploadResult.secure_url,
+              isMain: photoMeta.isMain ?? false,
+              description: photoMeta.description,
+            };
+          }),
         );
         updateTourDto.photos = uploadedPhotos;
       }

--- a/src/modules/tours/tours.schema.ts
+++ b/src/modules/tours/tours.schema.ts
@@ -1,4 +1,4 @@
-import { relations } from 'drizzle-orm';
+import { relations, sql } from 'drizzle-orm';
 import {
   boolean,
   date,
@@ -10,6 +10,7 @@ import {
   varchar,
   serial,
   char,
+  uniqueIndex,
 } from 'drizzle-orm/pg-core';
 import { operators } from '../operator/operator.schema';
 import { countries } from '../countries/countries.schema';
@@ -52,15 +53,25 @@ export const tours = pgTable('tours', {
   updatedAt: timestamp('updated_at').defaultNow(),
 });
 
-export const tourPhotos = pgTable('tour_photos', {
-  id: serial('id').primaryKey(),
-  tourId: integer('tour_id')
-    .references(() => tours.id, { onDelete: 'cascade' })
-    .notNull(),
-  url: varchar('url', { length: 255 }).unique().notNull(),
-  isMain: boolean('is_main').default(false).notNull(),
-  description: text('description'),
-});
+export const tourPhotos = pgTable(
+  'tour_photos',
+  {
+    id: serial('id').primaryKey(),
+    tourId: integer('tour_id')
+      .references(() => tours.id, { onDelete: 'cascade' })
+      .notNull(),
+    url: varchar('url', { length: 255 }).notNull(),
+    isMain: boolean('is_main').default(false).notNull(),
+    description: text('description'),
+  },
+  (table) => {
+    return {
+      mainPhotoIdx: uniqueIndex('main_photo_idx')
+        .on(table.tourId)
+        .where(sql`"is_main" = true`),
+    };
+  },
+);
 
 export const toursRelations = relations(tours, ({ one, many }) => ({
   operator: one(operators, {

--- a/src/modules/tours/tours.schema.ts
+++ b/src/modules/tours/tours.schema.ts
@@ -58,6 +58,8 @@ export const tourPhotos = pgTable('tour_photos', {
     .references(() => tours.id, { onDelete: 'cascade' })
     .notNull(),
   url: varchar('url', { length: 255 }).unique().notNull(),
+  isMain: boolean('is_main').default(false).notNull(),
+  description: text('description'),
 });
 
 export const toursRelations = relations(tours, ({ one, many }) => ({

--- a/src/modules/tours/tours.service.ts
+++ b/src/modules/tours/tours.service.ts
@@ -4,7 +4,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { CreateTourDto } from './dto/create-tour.dto';
+import { CreateTourDto, TourPhotoDto } from './dto/create-tour.dto';
 import { Tour } from './tours.types';
 import { GetToursQueryDto, SortOrder } from './dto/get-tours-query.dto';
 import { and, asc, desc, eq, gte, lte, sql } from 'drizzle-orm';
@@ -86,7 +86,9 @@ export class ToursService {
           if (mainPhotos.length > 1) {
             throw new BadRequestException('Only one photo can be set as main.');
           }
-          const tourPhotosToInsert = createTourDto.photos.map((photo) => ({
+          const tourPhotosToInsert = (
+            createTourDto.photos as TourPhotoDto[]
+          ).map((photo) => ({
             tourId: newTour.id,
             url: photo.url,
             isMain: photo.isMain,
@@ -370,7 +372,9 @@ export class ToursService {
           .where(eq(schema.tourPhotos.tourId, id));
 
         if (updateTourDto.photos.length > 0) {
-          const newPhotosToInsert = updateTourDto.photos.map((photo) => ({
+          const newPhotosToInsert = (
+            updateTourDto.photos as TourPhotoDto[]
+          ).map((photo) => ({
             tourId: id,
             url: photo.url,
             isMain: photo.isMain,

--- a/src/modules/tours/tours.service.ts
+++ b/src/modules/tours/tours.service.ts
@@ -82,9 +82,15 @@ export class ToursService {
         const newTour = result[0];
 
         if (createTourDto.photos && createTourDto.photos.length > 0) {
+          const mainPhotos = createTourDto.photos.filter((p) => p.isMain);
+          if (mainPhotos.length > 1) {
+            throw new BadRequestException('Only one photo can be set as main.');
+          }
           const tourPhotosToInsert = createTourDto.photos.map((photo) => ({
             tourId: newTour.id,
             url: photo.url,
+            isMain: photo.isMain,
+            description: photo.description,
           }));
 
           await tx.insert(schema.tourPhotos).values(tourPhotosToInsert);
@@ -355,6 +361,10 @@ export class ToursService {
       }
 
       if (updateTourDto.photos !== undefined) {
+        const mainPhotos = updateTourDto.photos.filter((p) => p.isMain);
+        if (mainPhotos.length > 1) {
+          throw new BadRequestException('Only one photo can be set as main.');
+        }
         await tx
           .delete(schema.tourPhotos)
           .where(eq(schema.tourPhotos.tourId, id));
@@ -363,6 +373,8 @@ export class ToursService {
           const newPhotosToInsert = updateTourDto.photos.map((photo) => ({
             tourId: id,
             url: photo.url,
+            isMain: photo.isMain,
+            description: photo.description,
           }));
           await tx.insert(schema.tourPhotos).values(newPhotosToInsert);
         }

--- a/src/modules/tours/tours.types.ts
+++ b/src/modules/tours/tours.types.ts
@@ -2,6 +2,8 @@ export interface TourPhoto {
   id: number;
   tourId: number;
   url: string;
+  isMain: boolean;
+  description: string | null;
 }
 
 interface Translation {


### PR DESCRIPTION
Feature/tour photos add is main description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Tours: Upload 1–10 photos with automatic validation (JPG/PNG, ≤5MB).
  - Photo metadata: Mark a single main photo and add optional descriptions; enforced on create/update.
  - Auth: Create, update, and delete tour endpoints require Bearer authentication.
  - Inputs: Photos accepted as files plus per-photo metadata (field renamed to photo_files); DTOs accept JSON/stringified or form-data inputs; adults no longer defaults to 1.

- Database
  - Tour photos now persist a main flag and description; DB enforces at most one main photo per tour.

- Documentation
  - API docs updated with Bearer scheme and revised photo upload/metadata fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->