### PR TITLE
Fix typescript warnings

### DIFF
--- a/src/common/interceptors/empty-string-to-undefined.interceptor.ts
+++ b/src/common/interceptors/empty-string-to-undefined.interceptor.ts
@@ -1,0 +1,24 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { Request } from 'express';
+
+@Injectable()
+export class EmptyStringToUndefinedInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const request: Request = context.switchToHttp().getRequest();
+    if (request.body) {
+      const body = request.body as Record<string, string | undefined>;
+      for (const key in body) {
+        if (body[key] === '') {
+          body[key] = undefined;
+        }
+      }
+    }
+    return next.handle();
+  }
+}

--- a/src/modules/tours/pipes/photo-validation.pipe.ts
+++ b/src/modules/tours/pipes/photo-validation.pipe.ts
@@ -1,9 +1,23 @@
 // src/modules/photos/pipes/photo-validation.pipe.ts
-import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
+import {
+  PipeTransform,
+  Injectable,
+  BadRequestException,
+  Scope,
+  Inject,
+} from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
 
-@Injectable()
+@Injectable({ scope: Scope.REQUEST })
 export class PhotoValidationPipe implements PipeTransform {
+  constructor(@Inject(REQUEST) private readonly request: Request) {}
   transform(files: Express.Multer.File[]) {
+    if (this.request.method === 'PATCH' || this.request.method === 'PUT') {
+      if (!files || files.length === 0) {
+        return files;
+      }
+    }
     if (!files || files.length === 0) {
       throw new BadRequestException('At least 1 photo is required.');
     }

--- a/src/modules/tours/tours.controller.ts
+++ b/src/modules/tours/tours.controller.ts
@@ -31,6 +31,7 @@ import { ApiBearerAuth, ApiConsumes } from '@nestjs/swagger';
 import { AuthenticatedRequest } from '@app/types/authenticated.request';
 import { JwtAuthGuard } from '@app/common/guards/jwt-auth.guard';
 import { PhotoValidationPipe } from './pipes';
+import { EmptyStringToUndefinedInterceptor } from '@app/common/interceptors/empty-string-to-undefined.interceptor';
 @Controller('tours')
 export class ToursController {
   constructor(
@@ -149,8 +150,10 @@ export class ToursController {
       transform: true,
       whitelist: true,
       forbidNonWhitelisted: true,
+      skipMissingProperties: true,
     }),
   )
+  @UseInterceptors(EmptyStringToUndefinedInterceptor)
   @UseInterceptors(
     FilesInterceptor('photo_files', 10, { storage: multer.memoryStorage() }),
   )

--- a/src/modules/tours/tours.module.ts
+++ b/src/modules/tours/tours.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { ToursService } from './tours.service';
 import { ToursController } from './tours.controller';
 import { CloudinaryModule } from '@app/cloudinary/cloudinary.module';
+import { PhotoValidationPipe } from './pipes';
 
 @Module({
   imports: [CloudinaryModule],
   controllers: [ToursController],
-  providers: [ToursService],
+  providers: [ToursService, PhotoValidationPipe],
 })
 export class ToursModule {}


### PR DESCRIPTION
Fix typescript warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partial updates for tours: missing fields are skipped during validation.
  * Empty form fields are treated as “unset,” enabling cleaner updates without sending empty-string values.

* **Bug Fixes**
  * PATCH/PUT no longer requires uploading photos when none are provided; existing photos remain unchanged.
  * Validation on update correctly respects optional fields, reducing unnecessary errors.

* **Enhancements**
  * Photo upload validation still enforces count, type and size limits while bypassing the "at least one" rule for partial updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->