### PR TITLE
Add checking that userId and tourId is an integer number

### DIFF
--- a/src/modules/bookings/dto/create-booking.dto.ts
+++ b/src/modules/bookings/dto/create-booking.dto.ts
@@ -1,11 +1,20 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsIn, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import {
+  IsIn,
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  Max,
+} from 'class-validator';
 
 // Створіть DTO для вхідних даних
 export class CreateBookingDto {
   @ApiProperty({ example: 1, description: 'ID of the tour to book' })
   @IsNumber()
   @IsNotEmpty()
+  @IsInt()
+  @Max(2147483647)
   tourId: number;
 
   @ApiProperty({
@@ -14,6 +23,8 @@ export class CreateBookingDto {
   })
   @IsNumber()
   @IsNotEmpty()
+  @IsInt()
+  @Max(2147483647)
   userId: number;
 
   @ApiProperty({


### PR DESCRIPTION
Add checking that userId and tourId is an integer number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Booking creation now validates tourId and userId as integers only; values above 2,147,483,647 are rejected.
  - Non-integer or out‑of‑range IDs return clear validation errors in responses.
  - Improved consistency of input validation for booking requests.
  - Existing valid requests continue to work without changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->