### PR TITLE
Fix do not allow to create new payment link when tour already exists

### DIFF
--- a/drizzle/0016_add_partial_unique_constraint_to_bookings.sql
+++ b/drizzle/0016_add_partial_unique_constraint_to_bookings.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX IF NOT EXISTS booking_user_tour_pending_idx ON "bookings" ("user_id", "tour_id") WHERE "status" = 'pending_payment';

--- a/src/modules/bookings/bookings.service.ts
+++ b/src/modules/bookings/bookings.service.ts
@@ -53,33 +53,33 @@ export class BookingsService {
 
     const totalPrice = tour.price; // Спрощений розрахунок
 
-    // 2. Check for an existing pending booking
-    const existingBooking = await this.db.query.bookings.findFirst({
-      where: (bookings, { and, eq }) =>
-        and(
-          eq(bookings.userId, data.userId),
-          eq(bookings.tourId, data.tourId),
-          eq(bookings.status, 'pending_payment'),
-        ),
-    });
-
-    if (existingBooking) {
-      throw new ConflictException(
-        'A pending booking for this tour and user already exists.',
-      );
+    let newBooking: typeof bookings.$inferSelect;
+    try {
+      [newBooking] = await this.db
+        .insert(bookings)
+        .values({
+          userId: data.userId,
+          tourId: data.tourId,
+          totalPrice: totalPrice,
+          currency: tour.currency,
+          paymentProvider: data.paymentProvider,
+          status: 'pending_payment',
+        })
+        .returning();
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        typeof (error as { code?: unknown }).code === 'string' &&
+        (error as { code: string }).code === '23505'
+      ) {
+        throw new ConflictException(
+          'A pending booking for this tour and user already exists.',
+        );
+      }
+      throw error;
     }
-
-    const [newBooking] = await this.db
-      .insert(bookings)
-      .values({
-        userId: data.userId,
-        tourId: data.tourId,
-        totalPrice: totalPrice,
-        currency: tour.currency,
-        paymentProvider: data.paymentProvider,
-        status: 'pending_payment',
-      })
-      .returning();
 
     // 3. Згенерувати посилання для оплати залежно від провайдера
     let paymentLink: string | undefined;

--- a/src/modules/bookings/bookings.service.ts
+++ b/src/modules/bookings/bookings.service.ts
@@ -1,4 +1,9 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import * as schema from '@app/db/schema/schema';
 import { bookings } from './bookings.schema';
 import LiqPay from 'liqpayjs-sdk'; // <-- Змінено тут
@@ -48,7 +53,22 @@ export class BookingsService {
 
     const totalPrice = tour.price; // Спрощений розрахунок
 
-    // 2. Створити попереднє бронювання в базі даних
+    // 2. Check for an existing pending booking
+    const existingBooking = await this.db.query.bookings.findFirst({
+      where: (bookings, { and, eq }) =>
+        and(
+          eq(bookings.userId, data.userId),
+          eq(bookings.tourId, data.tourId),
+          eq(bookings.status, 'pending_payment'),
+        ),
+    });
+
+    if (existingBooking) {
+      throw new ConflictException(
+        'A pending booking for this tour and user already exists.',
+      );
+    }
+
     const [newBooking] = await this.db
       .insert(bookings)
       .values({


### PR DESCRIPTION
Fix do not allow to create new payment link when tour already exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents creating multiple pending bookings for the same tour by the same user.
  * Returns a clear conflict message when an existing pending booking blocks a new request.
  * Reduces accidental duplicate reservations and related payment confusion, improving checkout reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->