### PR TITLE
Fix required for description

### DIFF
--- a/src/modules/tours/dto/create-tour.dto.ts
+++ b/src/modules/tours/dto/create-tour.dto.ts
@@ -76,7 +76,7 @@ export class CreateTourDto {
   @ApiProperty({
     description:
       'Detailed description of the tour program (e.g. "Explore the Eiffel Tower, Louvre Museum, and enjoy a Seine river cruise.")',
-    required: false,
+    required: true,
     default: '',
   })
   @IsString({ message: 'Description must be a string.' })

--- a/src/modules/tours/dto/get-tours-query.dto.ts
+++ b/src/modules/tours/dto/get-tours-query.dto.ts
@@ -121,36 +121,36 @@ export class GetToursQueryDto {
   @Type(() => Number)
   maxPrice?: number;
 
-  @ApiPropertyOptional({
-    example: null,
-    description: 'Number of adults in the tour (e.g., 2)',
-    minimum: 1,
-    required: false,
-  })
+  // @ApiPropertyOptional({
+  //   example: null,
+  //   description: 'Number of adults in the tour (e.g., 2)',
+  //   minimum: 1,
+  //   required: false,
+  // })
   @IsNumber()
   @IsOptional()
   @Min(1)
   @Type(() => Number)
   adults?: number; // Зняв default тут, щоб @IsOptional працював коректно
 
-  @ApiPropertyOptional({
-    example: null,
-    description: 'Number of children in the tour (e.g., 1)',
-    minimum: 0,
-    required: false,
-  })
+  // @ApiPropertyOptional({
+  //   example: null,
+  //   description: 'Number of children in the tour (e.g., 1)',
+  //   minimum: 0,
+  //   required: false,
+  // })
   @IsNumber()
   @IsOptional()
   @Min(0)
   @Type(() => Number)
   children?: number;
 
-  @ApiPropertyOptional({
-    example: null,
-    description: 'Are pets allowed on the tour? (default: false)',
-    type: Boolean,
-    required: false,
-  })
+  // @ApiPropertyOptional({
+  //   example: null,
+  //   description: 'Are pets allowed on the tour? (default: false)',
+  //   type: Boolean,
+  //   required: false,
+  // })
   @Transform(({ value }) =>
     value === true || value === 'true' || value === 1 || value === '1'
       ? true
@@ -162,22 +162,22 @@ export class GetToursQueryDto {
   @IsOptional()
   petsAllowed?: boolean; // Зняв default
 
-  @ApiPropertyOptional({
-    example: null,
-    description: 'ID of the departure city (reference to the cities table)',
-    default: '',
-    required: false,
-  })
+  // @ApiPropertyOptional({
+  //   example: null,
+  //   description: 'ID of the departure city (reference to the cities table)',
+  //   default: '',
+  //   required: false,
+  // })
   @Type(() => Number)
   @IsNumber()
   @IsOptional()
   @Min(1)
   departureCityId?: number;
 
-  @ApiPropertyOptional({
-    example: '',
-    description: 'ISO2 код країни відправлення туру ',
-  })
+  // @ApiPropertyOptional({
+  //   example: '',
+  //   description: 'ISO2 код країни відправлення туру ',
+  // })
   @Transform(({ value }): string | undefined =>
     typeof value === 'string' ? value.toUpperCase() : value,
   )


### PR DESCRIPTION
Fix required for description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Tour creation endpoint now marks “description” as required in the API documentation.
  * Removed the following query parameters from the tours listing API documentation: adults, children, petsAllowed, departureCityId, and departureCountryISO2Code. These filters remain supported but are no longer displayed in the docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->