### PR TITLE
Trimmed title from frontend

### DIFF
--- a/src/modules/tours/dto/create-tour.dto.ts
+++ b/src/modules/tours/dto/create-tour.dto.ts
@@ -62,7 +62,6 @@ export class CreateTourDto {
   @IsNotEmpty({ message: 'Title cannot be empty.' })
   @MinLength(3, { message: 'Title must be at least 3 characters long.' })
   @MaxLength(150, { message: 'Title cannot exceed 150 characters.' })
-  @NotContains('<', { message: 'Title cannot contain HTML tags.' })
   @NotContains('>', { message: 'Title cannot contain HTML tags.' })
   @Matches(
     /^(?!.*<[^>]*>)(?!.*([.,\-'""])\1)(?![.,\-'""])(?:[\p{L}\p{N} .,\-'""]+)(?<![.,\-'""])$/u,
@@ -70,6 +69,10 @@ export class CreateTourDto {
       message:
         'Title must not start or end with special characters, and special characters cannot be repeated.',
     },
+  )
+  @Transform(
+    ({ value }: { value: string | undefined }) =>
+      value?.trim() as unknown as string,
   )
   title: string;
 

--- a/src/modules/tours/dto/create-tour.dto.ts
+++ b/src/modules/tours/dto/create-tour.dto.ts
@@ -70,9 +70,8 @@ export class CreateTourDto {
         'Title must not start or end with special characters, and special characters cannot be repeated.',
     },
   )
-  @Transform(
-    ({ value }: { value: string | undefined }) =>
-      value?.trim() as unknown as string,
+  @Transform(({ value }: { value: string | undefined }) =>
+    value ? value.trim() : undefined,
   )
   title: string;
 


### PR DESCRIPTION
Trimmed title from frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tour title input now automatically trims leading and trailing spaces, ensuring cleaner, consistent formatting without extra effort.
  * Relaxed validation allows titles to include previously restricted characters (e.g., “<”), enabling more flexible naming.
  * Overall, this reduces unnecessary validation errors and improves the title entry experience when creating new tours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->