### PR TITLE
fix(operator): add validation to prevent numeric-only names

### DIFF
--- a/src/modules/operator/dto/create-operator.dto.ts
+++ b/src/modules/operator/dto/create-operator.dto.ts
@@ -7,6 +7,11 @@ import {
   Matches,
 } from 'class-validator';
 
+// Common name validation constants
+const NAME_PATTERN =
+  /^[A-Za-zА-Яа-яЁёЇїІіЄєҐґ](?:[ '-]?[A-Za-zА-Яа-яЁёЇїІіЄєҐґ])*$/;
+const NAME_ERROR_MESSAGE =
+  'must contain only letters, internal spaces, hyphens or apostrophes, and cannot start or end with a separator';
 export class CreateOperatorDto {
   [x: string]: string;
   @IsOptional()
@@ -35,8 +40,8 @@ export class CreateOperatorDto {
   @Length(2, 50, {
     message: 'First name must be between 2 and 50 characters',
   })
-  @Matches(/^[A-Za-zА-Яа-яЁёЇїІіЄєҐґ'’ -]+$/, {
-    message: 'First name must contain only letters and cannot include digits',
+  @Matches(NAME_PATTERN, {
+    message: `First name ${NAME_ERROR_MESSAGE}`,
   })
   firstName: string;
 
@@ -45,8 +50,8 @@ export class CreateOperatorDto {
   @Length(2, 50, {
     message: 'Last name must be between 2 and 50 characters',
   })
-  @Matches(/^[A-Za-zА-Яа-яЁёЇїІіЄєҐґ'’ -]+$/, {
-    message: 'Last name must contain only letters and cannot include digits',
+  @Matches(NAME_PATTERN, {
+    message: `Last name ${NAME_ERROR_MESSAGE}`,
   })
   lastName: string;
 

--- a/src/modules/operator/dto/create-operator.dto.ts
+++ b/src/modules/operator/dto/create-operator.dto.ts
@@ -35,12 +35,18 @@ export class CreateOperatorDto {
   @Length(2, 50, {
     message: 'First name must be between 2 and 50 characters',
   })
+  @Matches(/^[A-Za-zА-Яа-яЁёЇїІіЄєҐґ'’ -]+$/, {
+    message: 'First name must contain only letters and cannot include digits',
+  })
   firstName: string;
 
   @IsString()
   @IsNotEmpty({ message: 'LastName is required' })
   @Length(2, 50, {
     message: 'Last name must be between 2 and 50 characters',
+  })
+  @Matches(/^[A-Za-zА-Яа-яЁёЇїІіЄєҐґ'’ -]+$/, {
+    message: 'Last name must contain only letters and cannot include digits',
   })
   lastName: string;
 


### PR DESCRIPTION
This PR fixes a validation issue in the CreateOperatorDto where the API previously allowed creating tour operators with numeric-only or mixed names, such as "34" or "John123".

Now, firstName and lastName must contain letters only, supporting both Latin and Cyrillic characters, with optional spaces, apostrophes, and hyphens.

Changes

Added @Matches() validator for firstName and lastName in CreateOperatorDto.

Updated validation messages to provide clear feedback.

Tested validation using Postman with valid and invalid payloads.

Steps to Test

POST to /api/v1/operator with invalid payload:

{
  "firstName": "34",
  "lastName": "Ярмак",
  "website": "https://example.com",
  "phone": "+380501234567"
}


✅ Expected Result:

400 Bad Request

Error message: "First name must contain only letters and cannot include digits"

POST with valid payload:

{
  "firstName": "Іван",
  "lastName": "Петренко",
  "website": "https://example.com",
  "phone": "+380501234567"
}


✅ Expected Result:

201 Created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized name validation applied to first and last name fields, ensuring only letters (including Cyrillic and common diacritics), spaces, apostrophes, and hyphens are accepted.
  * Blocks digits and unsupported characters in name inputs to improve data quality.
  * Provides clearer, consistent error messages when name validation fails (e.g., during signup or profile updates).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->