### PR TITLE
Fix: improve phone number validation (no leading 0, 9-15 digits)

### DIFF
--- a/src/modules/operator/dto/create-operator.dto.ts
+++ b/src/modules/operator/dto/create-operator.dto.ts
@@ -25,8 +25,9 @@ export class CreateOperatorDto {
 
   @IsString()
   @IsNotEmpty({ message: 'Phone number is required' })
-  @Matches(/^\+?[0-9]{9,15}$/, {
-    message: 'Phone number must be valid and contain 9 to 15 digits',
+  @Matches(/^\+?[1-9][0-9]{8,14}$/, {
+    message:
+      'Phone number must be digits only (9–15 chars), cannot start with 0, may include optional + at start',
   })
   phone: string;
 


### PR DESCRIPTION
Description

This PR updates the phone number validation rules according to requirements:

Phone number must contain only digits (9–15 characters).

Cannot start with 0.

Optional leading + is allowed.

Clear error messages are returned when validation fails.

Examples:
✅ Valid: +380501234567, 9876543210
❌ Invalid: 0501234567, 50123abc, 50 123 4567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved phone number validation for operator creation: accepts digits-only with optional leading “+”, enforces 9–15 digits, and disallows numbers starting with zero.
  * Updated validation message to clearly explain the required format, helping users correct input errors more easily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->