### PR TITLE
fix: add proper validation rules for companyName in UpdateOperatorDto

### DIFF
--- a/src/modules/operator/dto/update-operator.dto.ts
+++ b/src/modules/operator/dto/update-operator.dto.ts
@@ -1,8 +1,20 @@
-import { IsOptional, IsString, IsUrl, Matches } from 'class-validator';
-
+import { IsOptional, IsString, IsUrl, Length, Matches } from 'class-validator';
+import { Transform } from 'class-transformer';
 export class UpdateOperatorDto {
   @IsOptional()
-  @IsString()
+  @Length(3, 100, {
+    message: 'Company name must be between 3 and 100 characters long',
+  })
+  @Matches(/^(?!.*(--|\.\.))[\p{L}\p{N}\s.,'"-]+$/u, {
+    message:
+      'Company name may only contain letters, numbers, spaces, and symbols . , \' " - without repeats',
+  })
+  @Transform(({ value }: { value: unknown }) => {
+    if (typeof value === 'string') {
+      return value.trim();
+    }
+    return value as string | undefined;
+  })
   companyName?: string;
 
   @IsOptional()


### PR DESCRIPTION
- Implemented validation for companyName according to story/design requirements.
- Added safe trim transform with proper TypeScript typing.
- Ensured ESLint passes without unsafe type warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved validation for the Company Name when updating an operator. The field remains optional, but when provided it is auto-trimmed and must be 3–100 characters. Only letters, numbers, spaces, and the symbols . , ' " - are allowed, and repeated sequences like “--” or “..” are blocked. Clearer error messages guide corrections, reducing invalid submissions and improving data quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->