### PR TITLE
Feature/tours photo delete

### DIFF
--- a/src/modules/tours/tours.controller.ts
+++ b/src/modules/tours/tours.controller.ts
@@ -306,20 +306,12 @@ export class ToursController {
     @Param('tourId', ParseIntPipe) tourId: number,
     @Param('photoId', ParseIntPipe) photoId: number,
     @Req() req: AuthenticatedRequest,
-  ): Promise<{ message: string }> {
+  ): Promise<void> {
     const operatorId = req.user.operatorId;
     if (!operatorId) {
       throw new BadRequestException('Operator ID not found.');
     }
 
-    const result = await this.toursService.deletePhoto(
-      tourId,
-      photoId,
-      operatorId,
-    );
-    if (!result) {
-      throw new NotFoundException('Failed to delete photo');
-    }
-    return { message: 'Photo deleted successfully' };
+    await this.toursService.deletePhoto(tourId, photoId, operatorId);
   }
 }

--- a/src/modules/tours/tours.controller.ts
+++ b/src/modules/tours/tours.controller.ts
@@ -19,7 +19,6 @@ import {
   BadRequestException,
   UseGuards,
   UploadedFile,
-  NotFoundException,
 } from '@nestjs/common';
 import { ToursService } from './tours.service';
 import { CreateTourDto } from './dto/create-tour.dto';

--- a/src/modules/tours/tours.controller.ts
+++ b/src/modules/tours/tours.controller.ts
@@ -19,6 +19,7 @@ import {
   BadRequestException,
   UseGuards,
   UploadedFile,
+  NotFoundException,
 } from '@nestjs/common';
 import { ToursService } from './tours.service';
 import { CreateTourDto } from './dto/create-tour.dto';
@@ -226,7 +227,6 @@ export class ToursController {
 
   @Delete(':id')
   @UseGuards(JwtAuthGuard)
-  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiBearerAuth('bearer')
   async remove(
     @Param('id', ParseIntPipe) id: number,
@@ -318,7 +318,7 @@ export class ToursController {
       operatorId,
     );
     if (!result) {
-      throw new BadRequestException('Failed to delete photo');
+      throw new NotFoundException('Failed to delete photo');
     }
     return { message: 'Photo deleted successfully' };
   }

--- a/src/modules/tours/tours.controller.ts
+++ b/src/modules/tours/tours.controller.ts
@@ -297,4 +297,29 @@ export class ToursController {
       );
     }
   }
+
+  @Delete(':tourId/photos/:photoId')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiBearerAuth('bearer')
+  async deletePhoto(
+    @Param('tourId', ParseIntPipe) tourId: number,
+    @Param('photoId', ParseIntPipe) photoId: number,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<{ message: string }> {
+    const operatorId = req.user.operatorId;
+    if (!operatorId) {
+      throw new BadRequestException('Operator ID not found.');
+    }
+
+    const result = await this.toursService.deletePhoto(
+      tourId,
+      photoId,
+      operatorId,
+    );
+    if (!result) {
+      throw new BadRequestException('Failed to delete photo');
+    }
+    return { message: 'Photo deleted successfully' };
+  }
 }

--- a/src/modules/tours/tours.service.ts
+++ b/src/modules/tours/tours.service.ts
@@ -56,6 +56,25 @@ export class ToursService {
       );
     }
   }
+  private async validateTourOwnership(
+    tourId: number,
+    operatorId: number,
+    tx: NodePgDatabase<typeof schema>,
+  ): Promise<typeof schema.tours.$inferSelect> {
+    const tour = await tx.query.tours.findFirst({
+      where: and(
+        eq(schema.tours.id, tourId),
+        eq(schema.tours.operatorId, operatorId),
+      ),
+    });
+
+    if (!tour) {
+      throw new NotFoundException(
+        `Tour with ID ${tourId} not found or you don't have permission to modify it.`,
+      );
+    }
+    return tour;
+  }
   async create(
     createTourDto: CreateTourDto,
     operatorId: number,
@@ -259,18 +278,11 @@ export class ToursService {
       try {
         const { photos, ...tourData } = updateTourDto;
 
-        const existingTour = await tx.query.tours.findFirst({
-          where: and(
-            eq(schema.tours.id, id),
-            eq(schema.tours.operatorId, operatorId),
-          ),
-        });
-
-        if (!existingTour) {
-          throw new NotFoundException(
-            `Tour with ID ${id} not found or you don't have permission to update it.`,
-          );
-        }
+        const existingTour = await this.validateTourOwnership(
+          id,
+          operatorId,
+          tx,
+        );
 
         const today = new Date();
         today.setHours(0, 0, 0, 0);
@@ -417,18 +429,7 @@ export class ToursService {
     photoUrl?: string,
   ): Promise<TourPhoto> {
     return await this.db.transaction(async (tx) => {
-      const tour = await tx.query.tours.findFirst({
-        where: and(
-          eq(schema.tours.id, tourId),
-          eq(schema.tours.operatorId, operatorId),
-        ),
-      });
-
-      if (!tour) {
-        throw new NotFoundException(
-          `Tour with ID ${tourId} not found or you don't have permission to update it.`,
-        );
-      }
+      await this.validateTourOwnership(tourId, operatorId, tx);
 
       const photo = await tx.query.tourPhotos.findFirst({
         where: and(
@@ -467,18 +468,7 @@ export class ToursService {
     operatorId: number,
   ): Promise<{ message: string }> {
     return await this.db.transaction(async (tx) => {
-      const tour = await tx.query.tours.findFirst({
-        where: and(
-          eq(schema.tours.id, tourId),
-          eq(schema.tours.operatorId, operatorId),
-        ),
-      });
-
-      if (!tour) {
-        throw new NotFoundException(
-          `Tour with ID ${tourId} not found or you don't have permission to modify it.`,
-        );
-      }
+      await this.validateTourOwnership(tourId, operatorId, tx);
 
       const photo = await tx.query.tourPhotos.findFirst({
         where: and(

--- a/src/modules/tours/tours.service.ts
+++ b/src/modules/tours/tours.service.ts
@@ -460,4 +460,49 @@ export class ToursService {
       return updatedPhoto;
     });
   }
+
+  async deletePhoto(
+    tourId: number,
+    photoId: number,
+    operatorId: number,
+  ): Promise<{ message: string }> {
+    return await this.db.transaction(async (tx) => {
+      const tour = await tx.query.tours.findFirst({
+        where: and(
+          eq(schema.tours.id, tourId),
+          eq(schema.tours.operatorId, operatorId),
+        ),
+      });
+
+      if (!tour) {
+        throw new NotFoundException(
+          `Tour with ID ${tourId} not found or you don't have permission to modify it.`,
+        );
+      }
+
+      const photo = await tx.query.tourPhotos.findFirst({
+        where: and(
+          eq(schema.tourPhotos.id, photoId),
+          eq(schema.tourPhotos.tourId, tourId),
+        ),
+      });
+
+      if (!photo) {
+        throw new NotFoundException(
+          `Photo with ID ${photoId} not found in tour ${tourId}.`,
+        );
+      }
+      if (photo.isMain) {
+        throw new BadRequestException(
+          'The main photo cannot be deleted. Please set another photo as main first.',
+        );
+      }
+
+      await tx
+        .delete(schema.tourPhotos)
+        .where(eq(schema.tourPhotos.id, photoId));
+
+      return { message: 'Photo deleted successfully.' };
+    });
+  }
 }


### PR DESCRIPTION
Feature/tours photo delete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an authenticated endpoint to delete a tour photo (DELETE /:tourId/photos/:photoId); requires operator context and returns 204 No Content.

- **Bug Fixes**
  - Prevents deletion of a tour’s main photo.
  - More accurate 404 responses when a tour or photo does not exist or is not owned by the operator.

- **Changes**
  - DELETE tour endpoint no longer returns No Content; now returns a response body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->