### PR TITLE
fix(operator): update name and surname validation rules in Create Ope…

### DIFF
--- a/src/modules/operator/dto/create-operator.dto.ts
+++ b/src/modules/operator/dto/create-operator.dto.ts
@@ -7,11 +7,12 @@ import {
   Matches,
 } from 'class-validator';
 
-// Common name validation constants
 const NAME_PATTERN =
-  /^[A-Za-zА-Яа-яЁёЇїІіЄєҐґ](?:[ '-]?[A-Za-zА-Яа-яЁёЇїІіЄєҐґ])*$/;
+  /^(?!.*(--|''))(?!(?:.*[-']$)|(?:^[-']))[A-Za-zА-Яа-яЁёЇїІіЄєҐґ'-]{2,50}$/;
+
 const NAME_ERROR_MESSAGE =
-  'must contain only letters, internal spaces, hyphens or apostrophes, and cannot start or end with a separator';
+  'must be 2–50 characters long, contain only letters (Latin or Cyrillic), single hyphens or apostrophes. ' +
+  'Digits, spaces, special characters, consecutive or leading/trailing separators are not allowed.';
 export class CreateOperatorDto {
   [x: string]: string;
   @IsOptional()


### PR DESCRIPTION
### Summary
Fixed the validation logic for `firstName` and `lastName` fields in the `CreateOperatorDto`.
Now the API correctly rejects invalid inputs such as:
- "ап"
- "@John!"
- "A--lex"
- "O''Connor"

### Changes
- Updated `NAME_PATTERN` regex to allow only letters, hyphens, and apostrophes.
- Improved validation messages for clarity.
- Added handling for duplicate operator creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  - More informative validation errors for first and last name fields, guiding users on allowed characters and length.
* Bug Fixes
  - Stricter name validation to prevent invalid inputs (e.g., digits, spaces, consecutive or leading/trailing separators).
  - Ensures consistent validation across first and last name fields during operator creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->