### PR TITLE
Add default establish isMain to the photos array

### DIFF
--- a/src/modules/tours/dto/create-tour.dto.ts
+++ b/src/modules/tours/dto/create-tour.dto.ts
@@ -217,7 +217,7 @@ export class CreateTourDto {
 
   @ApiPropertyOptional({
     description:
-      'Metadata for tour photos. The order should correspond to the uploaded files. Example: photos[0][isMain]=true&photos[0][description]=Main photo',
+      'Metadata for tour photos. The order should correspond to the uploaded files.',
     type: [TourPhotoDto],
   })
   // Трансформація для поля photos, щоб коректно обробляти різні формати вхідних даних (JSON-рядок, об'єкт, масив)

--- a/src/modules/tours/tours.controller.ts
+++ b/src/modules/tours/tours.controller.ts
@@ -130,7 +130,6 @@ export class ToursController {
         throw error;
       }
       // Handle the error here
-      console.error(error);
       throw new HttpException(
         'Failed to retrieve tours',
         HttpStatus.INTERNAL_SERVER_ERROR,

--- a/src/modules/tours/tours.service.ts
+++ b/src/modules/tours/tours.service.ts
@@ -91,9 +91,30 @@ export class ToursService {
           }));
 
           await tx.insert(schema.tourPhotos).values(tourPhotosToInsert);
+
+          const tourPhotos = await tx.query.tourPhotos.findMany({
+            where: eq(schema.tourPhotos.tourId, newTour.id),
+          });
+
+          const hasMainPhoto = tourPhotos.some((p) => p.isMain);
+
+          if (!hasMainPhoto && tourPhotos.length > 0) {
+            const firstPhoto = tourPhotos[0];
+            await tx
+              .update(schema.tourPhotos)
+              .set({ isMain: true })
+              .where(eq(schema.tourPhotos.id, firstPhoto.id));
+          }
         }
 
-        return newTour;
+        const finalTour = await tx.query.tours.findFirst({
+          where: eq(schema.tours.id, newTour.id),
+          with: { photos: true },
+        });
+        finalTour.photos.sort((a, b) =>
+          a.isMain === b.isMain ? 0 : a.isMain ? -1 : 1,
+        );
+        return finalTour;
       } catch (error) {
         if (error instanceof BadRequestException) {
           throw error;
@@ -171,7 +192,7 @@ export class ToursService {
 
     try {
       // Виконання запиту до бази даних
-      const allTours = await this.db.query.tours.findMany({
+      const preAllTours = await this.db.query.tours.findMany({
         // Використовуйте this.db
         where: and(...whereConditions),
         orderBy: orderFunction(orderByColumn),
@@ -196,7 +217,13 @@ export class ToursService {
           },
         },
       });
-
+      const allTours = preAllTours.map((tour) => ({
+        ...tour,
+        photos: tour.photos.sort((a, b) =>
+          a.isMain === b.isMain ? 0 : a.isMain ? -1 : 1,
+        ),
+      }));
+      // Отримання загальної кількості записів для пагінації
       const totalCountResult = await this.db // Використовуйте this.db
         .select({ count: sql<number>`count(*)` }) // Явно вказуємо, що count - це число
         .from(schema.tours) // Використовуйте schema.tours
@@ -250,7 +277,7 @@ export class ToursService {
         `Tour with ID ${id} not found or is inactive.`,
       );
     }
-
+    tour.photos.sort((a, b) => (a.isMain === b.isMain ? 0 : a.isMain ? -1 : 1));
     return tour;
   }
 
@@ -368,8 +395,34 @@ export class ToursService {
           );
         }
 
+        // Check if there is a main photo, if not, set the first one as main
+        const hasMainPhoto = tourWithPhotos.photos.some((p) => p.isMain);
+        if (!hasMainPhoto && tourWithPhotos.photos.length > 0) {
+          const firstPhoto = tourWithPhotos.photos[0];
+          await tx
+            .update(schema.tourPhotos)
+            .set({ isMain: true })
+            .where(eq(schema.tourPhotos.id, firstPhoto.id));
+          // Refresh tourWithPhotos to include the change
+          const refreshedTourWithPhotos = await tx.query.tours.findFirst({
+            where: eq(schema.tours.id, updatedTour.id),
+            with: { photos: true },
+          });
+          if (refreshedTourWithPhotos) {
+            return {
+              ...refreshedTourWithPhotos,
+              price: parseFloat(refreshedTourWithPhotos.price),
+              createdAt: refreshedTourWithPhotos.createdAt.toISOString(),
+              updatedAt: refreshedTourWithPhotos.updatedAt.toISOString(),
+            };
+          }
+        }
+
         return {
           ...tourWithPhotos,
+          photos: tourWithPhotos.photos.sort((a, b) =>
+            a.isMain === b.isMain ? 0 : a.isMain ? -1 : 1,
+          ),
           price: parseFloat(tourWithPhotos.price),
           createdAt: tourWithPhotos.createdAt.toISOString(),
           updatedAt: tourWithPhotos.updatedAt.toISOString(),
@@ -457,7 +510,30 @@ export class ToursService {
         .where(eq(schema.tourPhotos.id, photoId))
         .returning();
 
-      return updatedPhoto;
+      if (updateTourPhotoDto.isMain === false) {
+        const otherPhotos = await tx.query.tourPhotos.findMany({
+          where: and(
+            eq(schema.tourPhotos.tourId, tourId),
+            ne(schema.tourPhotos.id, photoId),
+          ),
+        });
+
+        const hasMainPhoto = otherPhotos.some((p) => p.isMain);
+
+        if (!hasMainPhoto && otherPhotos.length > 0) {
+          const firstPhoto = otherPhotos[0];
+          await tx
+            .update(schema.tourPhotos)
+            .set({ isMain: true })
+            .where(eq(schema.tourPhotos.id, firstPhoto.id));
+        }
+      }
+
+      const finalUpdatedPhoto = await tx.query.tourPhotos.findFirst({
+        where: eq(schema.tourPhotos.id, updatedPhoto.id),
+      });
+
+      return finalUpdatedPhoto;
     });
   }
 }


### PR DESCRIPTION
Add default establish isMain to the photos array

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures every tour has a main photo; auto-promotes the first photo if none is set.
  * Photos are consistently ordered with the main photo first across create, list, detail, and update flows.
  * Create and update now return fully composed tour data including photos.

* **Documentation**
  * Made the photos field description less prescriptive by removing a specific example about order and multipart upload.

* **Chores**
  * Removed runtime console error logs from error handling paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->