### PR TITLE
Add feature to delete tour photo

### DIFF
--- a/src/modules/tours/tours.controller.ts
+++ b/src/modules/tours/tours.controller.ts
@@ -298,8 +298,8 @@ export class ToursController {
 
   @Delete(':tourId/photos/:photoId')
   @UseGuards(JwtAuthGuard)
-  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiBearerAuth('bearer')
+  @HttpCode(HttpStatus.NO_CONTENT)
   async deletePhoto(
     @Param('tourId', ParseIntPipe) tourId: number,
     @Param('photoId', ParseIntPipe) photoId: number,

--- a/src/modules/tours/tours.service.ts
+++ b/src/modules/tours/tours.service.ts
@@ -558,15 +558,24 @@ export class ToursService {
           `Photo with ID ${photoId} not found in tour ${tourId}.`,
         );
       }
-      if (photo.isMain) {
-        throw new BadRequestException(
-          'The main photo cannot be deleted. Please set another photo as main first.',
-        );
-      }
 
       await tx
         .delete(schema.tourPhotos)
         .where(eq(schema.tourPhotos.id, photoId));
+
+      if (photo.isMain) {
+        const remainingPhotos = await tx.query.tourPhotos.findMany({
+          where: eq(schema.tourPhotos.tourId, tourId),
+          orderBy: asc(schema.tourPhotos.id),
+        });
+
+        if (remainingPhotos.length > 0) {
+          await tx
+            .update(schema.tourPhotos)
+            .set({ isMain: true })
+            .where(eq(schema.tourPhotos.id, remainingPhotos[0].id));
+        }
+      }
 
       return { message: 'Photo deleted successfully.' };
     });


### PR DESCRIPTION
Add feature to delete tour photo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now delete a tour’s main photo. If other photos remain, the earliest remaining photo is automatically set as the new main. If no photos remain, no main photo is set. This removes the previous restriction that blocked deleting the main photo.

* **Refactor**
  * Internal route annotations were reorganized with no functional impact or user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->