### PR TITLE
fix(validation): enforce non-empty phone, website, philosophy and validate photo format/size

### DIFF
--- a/src/common/validators/file-type-size.validator.ts
+++ b/src/common/validators/file-type-size.validator.ts
@@ -18,11 +18,10 @@ export function IsFileValid(
 
           const file = value as Express.Multer.File;
 
-          if (!file.mimetype || !file.size) return false;
+          if (!file?.mimetype || !file?.size) return false;
 
-          const [allowedMimeTypes, maxSize] = [mimeTypes, maxSizeMb];
-          const isMimeValid = allowedMimeTypes.includes(file.mimetype);
-          const isSizeValid = file.size <= maxSize * 1024 * 1024;
+          const isMimeValid = mimeTypes.includes(file.mimetype);
+          const isSizeValid = file.size <= maxSizeMb * 1024 * 1024;
 
           return isMimeValid && isSizeValid;
         },

--- a/src/common/validators/file-type-size.validator.ts
+++ b/src/common/validators/file-type-size.validator.ts
@@ -1,0 +1,37 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+
+export function IsFileValid(
+  mimeTypes: string[],
+  maxSizeMb: number,
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isFileValid',
+      target: object.constructor,
+      propertyName,
+      constraints: [mimeTypes, maxSizeMb],
+      options: validationOptions,
+      validator: {
+        validate(value: unknown): boolean {
+          if (!value) return true;
+
+          const file = value as Express.Multer.File;
+
+          if (!file.mimetype || !file.size) return false;
+
+          const [allowedMimeTypes, maxSize] = [mimeTypes, maxSizeMb];
+          const isMimeValid = allowedMimeTypes.includes(file.mimetype);
+          const isSizeValid = file.size <= maxSize * 1024 * 1024;
+
+          return isMimeValid && isSizeValid;
+        },
+        defaultMessage(): string {
+          return `File must be one of: ${mimeTypes.join(
+            ', ',
+          )} and smaller than ${maxSizeMb}MB`;
+        },
+      },
+    });
+  };
+}

--- a/src/modules/operator/dto/create-operator.dto.ts
+++ b/src/modules/operator/dto/create-operator.dto.ts
@@ -6,7 +6,7 @@ import {
   Length,
   Matches,
 } from 'class-validator';
-import { IsFileValid } from '../../common/validators/file-type-size.validator';
+import { IsFileValid } from '../../../common/validators/file-type-size.validator';
 
 const NAME_PATTERN =
   /^(?!.*(--|''))(?!(?:.*[-']$)|(?:^[-']))[A-Za-zА-Яа-яЁёЇїІіЄєҐґ'-]{2,50}$/;

--- a/src/modules/operator/dto/create-operator.dto.ts
+++ b/src/modules/operator/dto/create-operator.dto.ts
@@ -1,6 +1,5 @@
 import {
   IsEmpty,
-  IsNotEmpty,
   IsOptional,
   IsString,
   Length,
@@ -30,7 +29,6 @@ export class CreateOperatorDto {
   description?: string;
 
   @IsString()
-  @IsNotEmpty({ message: 'Phone number is required' })
   @Matches(/^\+?[1-9][0-9]{8,14}$/, {
     message:
       'Phone number must be digits only (9–15 chars), cannot start with 0, may include optional + at start',
@@ -38,7 +36,6 @@ export class CreateOperatorDto {
   phone: string;
 
   @IsString()
-  @IsNotEmpty({ message: 'Firstname is required' })
   @Length(2, 50, {
     message: 'First name must be between 2 and 50 characters',
   })
@@ -48,7 +45,6 @@ export class CreateOperatorDto {
   firstName: string;
 
   @IsString()
-  @IsNotEmpty({ message: 'LastName is required' })
   @Length(2, 50, {
     message: 'Last name must be between 2 and 50 characters',
   })
@@ -58,7 +54,6 @@ export class CreateOperatorDto {
   lastName: string;
 
   @IsString()
-  @IsNotEmpty({ message: 'Website is required' })
   @Matches(/^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[\w- ./?%&=]*)?$/, {
     message: 'Website must be a valid URL',
   })
@@ -70,8 +65,7 @@ export class CreateOperatorDto {
   @IsEmpty({ message: 'email cannot be provided in body' })
   email?: string;
 
-  @IsNotEmpty({ message: 'Photo is required' })
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  @IsOptional()
   @IsFileValid(['image/jpeg', 'image/png'], 5, {
     message: 'Photo must be JPEG or PNG and up to 5MB',
   })

--- a/src/modules/operator/dto/create-operator.dto.ts
+++ b/src/modules/operator/dto/create-operator.dto.ts
@@ -6,7 +6,7 @@ import {
   Length,
   Matches,
 } from 'class-validator';
-import { IsFileValid } from 'src/common/validators/file-type-size.validator';
+import { IsFileValid } from '../../common/validators/file-type-size.validator';
 
 const NAME_PATTERN =
   /^(?!.*(--|''))(?!(?:.*[-']$)|(?:^[-']))[A-Za-zА-Яа-яЁёЇїІіЄєҐґ'-]{2,50}$/;
@@ -70,6 +70,8 @@ export class CreateOperatorDto {
   @IsEmpty({ message: 'email cannot be provided in body' })
   email?: string;
 
+  @IsNotEmpty({ message: 'Photo is required' })
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   @IsFileValid(['image/jpeg', 'image/png'], 5, {
     message: 'Photo must be JPEG or PNG and up to 5MB',
   })

--- a/src/modules/operator/dto/create-operator.dto.ts
+++ b/src/modules/operator/dto/create-operator.dto.ts
@@ -6,6 +6,7 @@ import {
   Length,
   Matches,
 } from 'class-validator';
+import { IsFileValid } from 'src/common/validators/file-type-size.validator';
 
 const NAME_PATTERN =
   /^(?!.*(--|''))(?!(?:.*[-']$)|(?:^[-']))[A-Za-zА-Яа-яЁёЇїІіЄєҐґ'-]{2,50}$/;
@@ -14,7 +15,6 @@ const NAME_ERROR_MESSAGE =
   'must be 2–50 characters long, contain only letters (Latin or Cyrillic), single hyphens or apostrophes. ' +
   'Digits, spaces, special characters, consecutive or leading/trailing separators are not allowed.';
 export class CreateOperatorDto {
-  [x: string]: string;
   @IsOptional()
   @IsString()
   @Length(2, 100, {
@@ -69,4 +69,9 @@ export class CreateOperatorDto {
 
   @IsEmpty({ message: 'email cannot be provided in body' })
   email?: string;
+
+  @IsFileValid(['image/jpeg', 'image/png'], 5, {
+    message: 'Photo must be JPEG or PNG and up to 5MB',
+  })
+  photo: Express.Multer.File;
 }

--- a/src/modules/operator/dto/update-operator.dto.ts
+++ b/src/modules/operator/dto/update-operator.dto.ts
@@ -6,7 +6,7 @@ import {
   ValidateIf,
 } from 'class-validator';
 import { Transform } from 'class-transformer';
-import { IsFileValid } from 'src/common/validators/file-type-size.validator';
+import { IsFileValid } from '../../common/validators/file-type-size.validator';
 
 const NAME_PATTERN =
   /^(?!.*(--|''))(?!(?:.*[-']$)|(?:^[-']))[A-Za-zА-Яа-яЁёЇїІіЄєҐґ'-]{2,50}$/;
@@ -91,7 +91,8 @@ export class UpdateOperatorDto {
   })
   website?: string;
 
-  @ValidateIf((o: UpdateOperatorDto) => o.photo !== undefined)
+  @ValidateIf((o: UpdateOperatorDto) => !!o.photo)
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   @IsFileValid(['image/jpeg', 'image/png'], 5, {
     message: 'Photo must be JPEG or PNG and up to 5MB',
   })

--- a/src/modules/operator/dto/update-operator.dto.ts
+++ b/src/modules/operator/dto/update-operator.dto.ts
@@ -6,6 +6,7 @@ import {
   ValidateIf,
 } from 'class-validator';
 import { Transform } from 'class-transformer';
+import { IsFileValid } from 'src/common/validators/file-type-size.validator';
 
 const NAME_PATTERN =
   /^(?!.*(--|''))(?!(?:.*[-']$)|(?:^[-']))[A-Za-zА-Яа-яЁёЇїІіЄєҐґ'-]{2,50}$/;
@@ -13,6 +14,8 @@ const NAME_PATTERN =
 const NAME_ERROR_MESSAGE =
   'must be 2–50 characters long, contain only letters (Latin or Cyrillic), single hyphens or apostrophes. ' +
   'Digits, spaces, special characters, consecutive or leading/trailing separators are not allowed.';
+
+const NO_HTML_PATTERN = /^[^<>]*$/;
 
 export class UpdateOperatorDto {
   @IsOptional()
@@ -28,16 +31,24 @@ export class UpdateOperatorDto {
   })
   companyName?: string;
 
+  @ValidateIf(
+    (o: UpdateOperatorDto) => o.philosophy !== undefined && o.philosophy !== '',
+  )
+  @IsString()
+  @Length(0, 1000, {
+    message: 'Philosophy must be at most 1000 characters long',
+  })
+  @Matches(NO_HTML_PATTERN, {
+    message: 'Philosophy must not contain HTML tags',
+  })
+  philosophy?: string;
+
   @IsOptional()
   @IsString()
   @Length(10, 500, {
     message: 'Description must be between 10 and 500 characters',
   })
   description?: string;
-
-  @IsOptional()
-  @IsString()
-  philosophy?: string;
 
   @ValidateIf((o: UpdateOperatorDto) => o.phone !== undefined && o.phone !== '')
   @IsString()
@@ -79,4 +90,10 @@ export class UpdateOperatorDto {
     message: 'Website must be a valid URL',
   })
   website?: string;
+
+  @ValidateIf((o: UpdateOperatorDto) => o.photo !== undefined)
+  @IsFileValid(['image/jpeg', 'image/png'], 5, {
+    message: 'Photo must be JPEG or PNG and up to 5MB',
+  })
+  photo?: Express.Multer.File;
 }

--- a/src/modules/operator/dto/update-operator.dto.ts
+++ b/src/modules/operator/dto/update-operator.dto.ts
@@ -6,7 +6,7 @@ import {
   ValidateIf,
 } from 'class-validator';
 import { Transform } from 'class-transformer';
-import { IsFileValid } from '../../common/validators/file-type-size.validator';
+import { IsFileValid } from '../../../common/validators/file-type-size.validator';
 
 const NAME_PATTERN =
   /^(?!.*(--|''))(?!(?:.*[-']$)|(?:^[-']))[A-Za-zА-Яа-яЁёЇїІіЄєҐґ'-]{2,50}$/;


### PR DESCRIPTION
Summary:
Ensure PATCH and POST endpoints validate operator data consistently.

What was done:
- Added strict validation to UpdateOperatorDto and CreateOperatorDto:
  - phone: same regex as create (9–15 digits, optional +, cannot start with 0)
  - website: URL validation (same pattern as create)
  - philosophy: max length enforced, HTML tags disallowed
- Added file validator for photo (IsFileValid):
  - allows only image/jpeg and image/png
  - max size 5 MB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional photo upload on create and optional on update — accepts JPEG/PNG up to 5MB with validation.
  * Added reusable file-type/size validation for uploads to block unsupported formats and oversized files.
  * Enhanced "philosophy" validation on update: optional, text-only, max 1000 characters, disallows HTML tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->