### PR TITLE
fix: improve website URL validation to accept valid URLs per specific…

### DIFF
--- a/src/modules/operator/dto/create-operator.dto.ts
+++ b/src/modules/operator/dto/create-operator.dto.ts
@@ -54,9 +54,16 @@ export class CreateOperatorDto {
   lastName: string;
 
   @IsString()
-  @Matches(/^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[\w- ./?%&=]*)?$/, {
-    message: 'Website must be a valid URL',
+  @Length(1, 255, {
+    message: 'Website URL must be at most 255 characters long',
   })
+  @Matches(
+    /^(https?:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?::\d{1,5})?(\/[^\s]*)?$/,
+    {
+      message:
+        'Website must start with http:// or https://, contain a valid domain, and not include spaces',
+    },
+  )
   website: string;
 
   @IsEmpty({ message: 'id cannot be provided in body' })

--- a/src/modules/operator/dto/create-operator.dto.ts
+++ b/src/modules/operator/dto/create-operator.dto.ts
@@ -13,6 +13,11 @@ const NAME_PATTERN =
 const NAME_ERROR_MESSAGE =
   'must be 2–50 characters long, contain only letters (Latin or Cyrillic), single hyphens or apostrophes. ' +
   'Digits, spaces, special characters, consecutive or leading/trailing separators are not allowed.';
+const WEBSITE_URL_PATTERN =
+  /^(https?:\/\/)([a-zA-Z0-9]+([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}(?::\d{1,5})?(\/[^\s]*)?$/;
+
+const WEBSITE_URL_ERROR_MESSAGE =
+  'Website must start with http:// or https://, contain a valid domain, and not include spaces';
 export class CreateOperatorDto {
   @IsOptional()
   @IsString()
@@ -54,16 +59,12 @@ export class CreateOperatorDto {
   lastName: string;
 
   @IsString()
-  @Length(1, 255, {
-    message: 'Website URL must be at most 255 characters long',
+  @Length(13, 255, {
+    message: 'Website URL must be between 13 and 255 characters long',
   })
-  @Matches(
-    /^(https?:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?::\d{1,5})?(\/[^\s]*)?$/,
-    {
-      message:
-        'Website must start with http:// or https://, contain a valid domain, and not include spaces',
-    },
-  )
+  @Matches(WEBSITE_URL_PATTERN, {
+    message: WEBSITE_URL_ERROR_MESSAGE,
+  })
   website: string;
 
   @IsEmpty({ message: 'id cannot be provided in body' })

--- a/src/modules/operator/dto/create-operator.dto.ts
+++ b/src/modules/operator/dto/create-operator.dto.ts
@@ -14,7 +14,7 @@ const NAME_ERROR_MESSAGE =
   'must be 2–50 characters long, contain only letters (Latin or Cyrillic), single hyphens or apostrophes. ' +
   'Digits, spaces, special characters, consecutive or leading/trailing separators are not allowed.';
 const WEBSITE_URL_PATTERN =
-  /^(https?:\/\/)([a-zA-Z0-9]+([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}(?::\d{1,5})?(\/[^\s]*)?$/;
+  /^(https?:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?::\d{1,5})?(\/[^\s]*)?$/;
 
 const WEBSITE_URL_ERROR_MESSAGE =
   'Website must start with http:// or https://, contain a valid domain, and not include spaces';

--- a/src/modules/operator/dto/update-operator.dto.ts
+++ b/src/modules/operator/dto/update-operator.dto.ts
@@ -16,6 +16,11 @@ const NAME_ERROR_MESSAGE =
   'Digits, spaces, special characters, consecutive or leading/trailing separators are not allowed.';
 
 const NO_HTML_PATTERN = /^[^<>]*$/;
+const WEBSITE_URL_PATTERN =
+  /^(https?:\/\/)([a-zA-Z0-9]+([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}(?::\d{1,5})?(\/[^\s]*)?$/;
+
+const WEBSITE_URL_ERROR_MESSAGE =
+  'Website must start with http:// or https://, contain a valid domain, and not include spaces';
 
 export class UpdateOperatorDto {
   @IsOptional()
@@ -86,17 +91,13 @@ export class UpdateOperatorDto {
     (o: UpdateOperatorDto) => o.website !== undefined && o.website !== '',
   )
   @IsString()
-  @Length(1, 255, {
-    message: 'Website URL must be at most 255 characters long',
+  @Length(13, 255, {
+    message: 'Website URL must be between 13 and 255 characters long',
   })
-  @Matches(
-    /^(https?:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?::\d{1,5})?(\/[^\s]*)?$/,
-    {
-      message:
-        'Website must start with http:// or https://, contain a valid domain, and not include spaces',
-    },
-  )
-  website: string;
+  @Matches(WEBSITE_URL_PATTERN, {
+    message: WEBSITE_URL_ERROR_MESSAGE,
+  })
+  website?: string;
 
   @ValidateIf((o: UpdateOperatorDto) => !!o.photo)
   @IsFileValid(['image/jpeg', 'image/png'], 5, {

--- a/src/modules/operator/dto/update-operator.dto.ts
+++ b/src/modules/operator/dto/update-operator.dto.ts
@@ -86,13 +86,19 @@ export class UpdateOperatorDto {
     (o: UpdateOperatorDto) => o.website !== undefined && o.website !== '',
   )
   @IsString()
-  @Matches(/^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[\w- ./?%&=]*)?$/, {
-    message: 'Website must be a valid URL',
+  @Length(1, 255, {
+    message: 'Website URL must be at most 255 characters long',
   })
-  website?: string;
+  @Matches(
+    /^(https?:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?::\d{1,5})?(\/[^\s]*)?$/,
+    {
+      message:
+        'Website must start with http:// or https://, contain a valid domain, and not include spaces',
+    },
+  )
+  website: string;
 
   @ValidateIf((o: UpdateOperatorDto) => !!o.photo)
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   @IsFileValid(['image/jpeg', 'image/png'], 5, {
     message: 'Photo must be JPEG or PNG and up to 5MB',
   })

--- a/src/modules/operator/dto/update-operator.dto.ts
+++ b/src/modules/operator/dto/update-operator.dto.ts
@@ -17,7 +17,7 @@ const NAME_ERROR_MESSAGE =
 
 const NO_HTML_PATTERN = /^[^<>]*$/;
 const WEBSITE_URL_PATTERN =
-  /^(https?:\/\/)([a-zA-Z0-9]+([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}(?::\d{1,5})?(\/[^\s]*)?$/;
+  /^(https?:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?::\d{1,5})?(\/[^\s]*)?$/;
 
 const WEBSITE_URL_ERROR_MESSAGE =
   'Website must start with http:// or https://, contain a valid domain, and not include spaces';


### PR DESCRIPTION
Updated URL validation regex in CreateOperatorDto and UpdateOperatorDto to correctly accept valid URLs according to specification (including ports, query params, fragments, and subdomains).
Fixed issue where valid URLs like https://sub.domain-example.co.uk:8080/path?query=1#frag were incorrectly rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened website URL validation to require http:// or https://
  * Website URLs now limited to 13–255 characters
  * Spaces and invalid domain/port/path formats are rejected
  * Website field remains optional for operator updates
  * Improved, consistent error messages explaining URL requirements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->