### PR TITLE
fix validation  phone number in  create operator

### DIFF
--- a/src/modules/operator/dto/create-operator.dto.ts
+++ b/src/modules/operator/dto/create-operator.dto.ts
@@ -34,9 +34,9 @@ export class CreateOperatorDto {
   description?: string;
 
   @IsString()
-  @Matches(/^\+?[1-9][0-9]{8,14}$/, {
+  @Matches(/^\+?\d{1,3}\d{9,15}$/, {
     message:
-      'Phone number must be digits only (9–15 chars), cannot start with 0, may include optional + at start',
+      'Phone number must contain a 1–3 digit country code and 9–15 digits after it, only digits are allowed, optional + at the start',
   })
   phone: string;
 


### PR DESCRIPTION
fix(validation): update phone number regex to require 1–3 digit country code and 9–15 digits after it

- Updated phone validation in CreateOperatorDto and UpdateOperatorDto
- Ensured support for country codes like +380 or +1
- Removed old regex that incorrectly validated total digit count
- Aligned validation rules based on QA requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated phone number validation to accept a 1–3 digit country code followed by 9–15 digits, with an optional leading `+` symbol. The validation error message has been updated to reflect these new requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->