### PR TITLE
add reject operator endpoint with rejection reason

### DIFF
--- a/src/common/decorators/roles.decorator.ts
+++ b/src/common/decorators/roles.decorator.ts
@@ -1,3 +1,0 @@
-import { SetMetadata } from '@nestjs/common';
-
-export const Roles = (...roles: string[]) => SetMetadata('roles', roles);

--- a/src/common/decorators/roles.decorator.ts
+++ b/src/common/decorators/roles.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const Roles = (...roles: string[]) => SetMetadata('roles', roles);

--- a/src/common/guards/roles.guard.ts
+++ b/src/common/guards/roles.guard.ts
@@ -1,0 +1,36 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+interface UserWithRole {
+  role: string;
+  [key: string]: any;
+}
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly requiredRole: string) {}
+
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request = context
+      .switchToHttp()
+      .getRequest<{ user?: UserWithRole }>();
+
+    const user = request.user;
+    if (!user) {
+      throw new ForbiddenException('User not found in request');
+    }
+
+    if (user.role !== this.requiredRole) {
+      throw new ForbiddenException('Access denied: insufficient role');
+    }
+
+    return true;
+  }
+}

--- a/src/modules/admin/admin-operators.controller.ts
+++ b/src/modules/admin/admin-operators.controller.ts
@@ -1,22 +1,35 @@
 import {
   Controller,
   Get,
+  Patch,
   UseGuards,
   Query,
   Req,
+  Param,
+  ParseIntPipe,
+  Body,
   ForbiddenException,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags, ApiQuery } from '@nestjs/swagger';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  ApiQuery,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { OperatorService } from '@app/modules/operator/operator.service';
 import { JwtAuthGuard } from '@app/common/guards/jwt-auth.guard';
 import { AdminOperatorListDto } from './dto/admin-operator-list.dto';
+import { RejectOperatorDto } from './dto/reject-operator.dto';
 import { Request } from 'express';
 
 @ApiTags('Admin')
+@ApiBearerAuth()
 @Controller('admin/operators')
 export class AdminOperatorsController {
   constructor(private readonly operatorService: OperatorService) {}
 
+  // ================= GET PENDING OPERATORS =================
   @UseGuards(JwtAuthGuard)
   @Get()
   @ApiQuery({ name: 'limit', required: false, type: Number, example: 50 })
@@ -32,7 +45,6 @@ export class AdminOperatorsController {
     @Query('limit') limit?: number,
     @Query('offset') offset?: number,
   ): Promise<AdminOperatorListDto[]> {
-    // 🔒 Ручна перевірка ролі адміністратора
     if (req.user?.role !== 'admin') {
       throw new ForbiddenException('Доступ дозволено лише адміністраторам');
     }
@@ -48,5 +60,37 @@ export class AdminOperatorsController {
       email: op.email,
       status: op.status,
     }));
+  }
+
+  // ================= PATCH REJECT OPERATOR =================
+  @UseGuards(JwtAuthGuard)
+  @Patch(':id/reject')
+  @ApiOperation({ summary: 'Відхилити заявку оператора з причиною' })
+  @ApiResponse({
+    status: 200,
+    description: 'Оператор відхилений успішно',
+    type: AdminOperatorListDto,
+  })
+  async rejectOperator(
+    @Req() req: Request & { user: { role: string } },
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: RejectOperatorDto,
+  ): Promise<AdminOperatorListDto> {
+    if (req.user?.role !== 'admin') {
+      throw new ForbiddenException('Доступ дозволено лише адміністраторам');
+    }
+
+    const rejectedOperator = await this.operatorService.rejectOperator(
+      id,
+      dto.rejectionReason,
+    );
+
+    return {
+      firstName: rejectedOperator.firstName,
+      lastName: rejectedOperator.lastName,
+      email: rejectedOperator.email,
+      status: rejectedOperator.status,
+      rejectionReason: rejectedOperator.rejectionReason,
+    };
   }
 }

--- a/src/modules/admin/admin-operators.controller.ts
+++ b/src/modules/admin/admin-operators.controller.ts
@@ -22,6 +22,7 @@ import { JwtAuthGuard } from '@app/common/guards/jwt-auth.guard';
 import { AdminOperatorListDto } from './dto/admin-operator-list.dto';
 import { RejectOperatorDto } from './dto/reject-operator.dto';
 import { Request } from 'express';
+import { OperatorStatus } from '@app/types/operator-status';
 
 @ApiTags('Admin')
 @ApiBearerAuth()
@@ -42,24 +43,31 @@ export class AdminOperatorsController {
   })
   async getPendingOperators(
     @Req() req: Request & { user: { role: string } },
-    @Query('limit') limit?: number,
-    @Query('offset') offset?: number,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
   ): Promise<AdminOperatorListDto[]> {
     if (req.user?.role !== 'admin') {
       throw new ForbiddenException('Доступ дозволено лише адміністраторам');
     }
 
+    const limitNumber = limit ? Number(limit) : undefined;
+    const offsetNumber = offset ? Number(offset) : undefined;
+
     const operators = await this.operatorService.getOperatorsForVerification(
-      limit,
-      offset,
+      limitNumber,
+      offsetNumber,
     );
 
-    return operators.map((op) => ({
-      firstName: op.firstName,
-      lastName: op.lastName,
-      email: op.email,
-      status: op.status,
-    }));
+    return operators.map((op) => {
+      const dto: AdminOperatorListDto = {
+        firstName: op.firstName,
+        lastName: op.lastName,
+        email: op.email,
+        status: op.status as OperatorStatus,
+        rejectionReason: op.rejectionReason ?? undefined,
+      };
+      return dto;
+    });
   }
 
   // ================= PATCH REJECT OPERATOR =================
@@ -85,12 +93,14 @@ export class AdminOperatorsController {
       dto.rejectionReason,
     );
 
-    return {
+    const result: AdminOperatorListDto = {
       firstName: rejectedOperator.firstName,
       lastName: rejectedOperator.lastName,
       email: rejectedOperator.email,
-      status: rejectedOperator.status,
-      rejectionReason: rejectedOperator.rejectionReason,
+      status: rejectedOperator.status as OperatorStatus,
+      rejectionReason: rejectedOperator.rejectionReason ?? undefined,
     };
+
+    return result;
   }
 }

--- a/src/modules/admin/dto/admin-operator-list.dto.ts
+++ b/src/modules/admin/dto/admin-operator-list.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { OperatorStatus } from '@app/types/operator-status';
 
 export class AdminOperatorListDto {
   @ApiProperty()
@@ -10,8 +11,8 @@ export class AdminOperatorListDto {
   @ApiProperty()
   email: string;
 
-  @ApiProperty()
-  status: string;
+  @ApiProperty({ enum: OperatorStatus })
+  status: OperatorStatus;
 
   @ApiProperty({ required: false })
   rejectionReason?: string;

--- a/src/modules/admin/dto/admin-operator-list.dto.ts
+++ b/src/modules/admin/dto/admin-operator-list.dto.ts
@@ -12,4 +12,7 @@ export class AdminOperatorListDto {
 
   @ApiProperty()
   status: string;
+
+  @ApiProperty({ required: false })
+  rejectionReason?: string;
 }

--- a/src/modules/admin/dto/reject-operator.dto.ts
+++ b/src/modules/admin/dto/reject-operator.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RejectOperatorDto {
+  @ApiProperty({ description: 'Причина відхилення заявки оператора' })
+  @IsString()
+  @IsNotEmpty({ message: 'Rejection reason is required' })
+  rejectionReason: string;
+}

--- a/src/modules/operator/operator.controller.spec.ts
+++ b/src/modules/operator/operator.controller.spec.ts
@@ -46,6 +46,7 @@ describe('OperatorController', () => {
     status: 'approved',
     philosophy: null,
     photo: null,
+    rejectionReason: '',
     createdAt: new Date(),
     updatedAt: new Date(),
   };

--- a/src/modules/operator/operator.schema.ts
+++ b/src/modules/operator/operator.schema.ts
@@ -19,4 +19,5 @@ export const operators = pgTable('operators', {
   status: text('status').default('pending').notNull(),
   philosophy: text('philosophy'),
   photo: text('photo'),
+  rejectionReason: text('rejection_reason').default('').notNull(),
 });

--- a/src/modules/operator/operator.schema.ts
+++ b/src/modules/operator/operator.schema.ts
@@ -19,5 +19,5 @@ export const operators = pgTable('operators', {
   status: text('status').default('pending').notNull(),
   philosophy: text('philosophy'),
   photo: text('photo'),
-  rejectionReason: text('rejection_reason').default('').notNull(),
+  rejectionReason: text('rejection_reason'),
 });

--- a/src/modules/operator/operator.service.spec.ts
+++ b/src/modules/operator/operator.service.spec.ts
@@ -49,6 +49,7 @@ describe('OperatorService', () => {
     status: 'approved',
     philosophy: null,
     photo: null,
+    rejectionReason: '',
     createdAt: new Date(),
     updatedAt: new Date(),
   };

--- a/src/modules/operator/operator.service.ts
+++ b/src/modules/operator/operator.service.ts
@@ -126,6 +126,28 @@ export class OperatorService {
       .limit(limit)
       .offset(offset);
   }
+  async rejectOperator(id: number, rejectionReason: string) {
+    const operator = await this.db
+      .select()
+      .from(operatorSchema.operators)
+      .where(eq(operatorSchema.operators.id, id));
+
+    if (!operator[0]) {
+      throw new NotFoundException(`Operator with id ${id} not found`);
+    }
+
+    const updatedOperator = await this.db
+      .update(operatorSchema.operators)
+      .set({
+        status: 'rejected',
+        rejectionReason,
+        updatedAt: new Date(),
+      })
+      .where(eq(operatorSchema.operators.id, id))
+      .returning();
+
+    return updatedOperator[0];
+  }
   async getOperatorsForVerification(limit = 50, offset = 0) {
     return await this.db
       .select({

--- a/src/modules/operator/operator.service.ts
+++ b/src/modules/operator/operator.service.ts
@@ -14,6 +14,9 @@ import { CloudinaryService } from '@app/cloudinary/cloudinary.service';
 import { AuthenticatedRequest } from '@app/types/authenticated.request';
 import { OperatorStatus } from '@app/types/operator-status';
 import * as schema from '@app/db/schema/schema';
+import { operators } from '@app/modules/operator/operator.schema';
+
+type OperatorSelect = typeof operators.$inferSelect;
 @Injectable()
 export class OperatorService {
   constructor(
@@ -130,16 +133,21 @@ export class OperatorService {
     const operator = await this.db
       .select()
       .from(operatorSchema.operators)
-      .where(eq(operatorSchema.operators.id, id));
+      .where(eq(operatorSchema.operators.id, id))
+      .then((res) => res[0]);
 
-    if (!operator[0]) {
+    if (!operator) {
       throw new NotFoundException(`Operator with id ${id} not found`);
+    }
+
+    if (operator.status !== OperatorStatus.PENDING.toString()) {
+      throw new BadRequestException('Operator must be pending to be rejected');
     }
 
     const updatedOperator = await this.db
       .update(operatorSchema.operators)
       .set({
-        status: 'rejected',
+        status: OperatorStatus.REJECTED,
         rejectionReason,
         updatedAt: new Date(),
       })
@@ -148,16 +156,14 @@ export class OperatorService {
 
     return updatedOperator[0];
   }
-  async getOperatorsForVerification(limit = 50, offset = 0) {
+  async getOperatorsForVerification(
+    limit = 50,
+    offset = 0,
+  ): Promise<OperatorSelect[]> {
     return await this.db
-      .select({
-        firstName: operatorSchema.operators.firstName,
-        lastName: operatorSchema.operators.lastName,
-        email: operatorSchema.operators.email,
-        status: operatorSchema.operators.status,
-      })
-      .from(operatorSchema.operators)
-      .where(eq(operatorSchema.operators.status, OperatorStatus.PENDING))
+      .select()
+      .from(operators)
+      .where(eq(operators.status, OperatorStatus.PENDING))
       .limit(limit)
       .offset(offset);
   }


### PR DESCRIPTION
Add PATCH /admin/operators/:id/reject endpoint for admins
- Added `rejectionReason` field to Operator model
- Implemented PATCH /admin/operators/:id/reject endpoint
- Validates presence of rejection reason
- Restricted access to admin users only
- Updated Swagger docs for new endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can now reject operator applications with a rejection reason that is stored and displayed in the operator list.
  * Operator status is now properly typed as an enumeration for better data consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->