### PR TITLE
feat(admin-operators): add endpoint to approve operator

### DIFF
--- a/src/modules/admin/admin-operators.controller.ts
+++ b/src/modules/admin/admin-operators.controller.ts
@@ -70,6 +70,32 @@ export class AdminOperatorsController {
     });
   }
 
+  @UseGuards(JwtAuthGuard)
+  @Patch(':id/verify')
+  @ApiOperation({ summary: 'Верифікувати (погодити) заявку оператора' })
+  @ApiResponse({
+    status: 200,
+    description: 'Оператор верифікований успішно',
+    type: AdminOperatorListDto,
+  })
+  async verifyOperator(
+    @Req() req: Request & { user: { role: string } },
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<AdminOperatorListDto> {
+    if (req.user?.role !== 'admin') {
+      throw new ForbiddenException('Доступ дозволено лише адміністраторам');
+    }
+
+    const approvedOperator = await this.operatorService.verifyOperator(id);
+
+    return {
+      firstName: approvedOperator.firstName,
+      lastName: approvedOperator.lastName,
+      email: approvedOperator.email,
+      status: approvedOperator.status as OperatorStatus,
+      rejectionReason: approvedOperator.rejectionReason ?? undefined,
+    };
+  }
   // ================= PATCH REJECT OPERATOR =================
   @UseGuards(JwtAuthGuard)
   @Patch(':id/reject')

--- a/src/modules/operator/operator.service.ts
+++ b/src/modules/operator/operator.service.ts
@@ -129,6 +129,31 @@ export class OperatorService {
       .limit(limit)
       .offset(offset);
   }
+  async verifyOperator(id: number) {
+    const operator = await this.db
+      .select()
+      .from(operatorSchema.operators)
+      .where(eq(operatorSchema.operators.id, id))
+      .then((res) => res[0]);
+
+    if (!operator) {
+      throw new NotFoundException(`Operator with id ${id} not found`);
+    }
+
+    const status = operator.status as OperatorStatus;
+
+    if (status !== OperatorStatus.PENDING) {
+      throw new BadRequestException('Operator must be pending to be approved');
+    }
+
+    const updatedOperator = await this.db
+      .update(operatorSchema.operators)
+      .set({ status: OperatorStatus.APPROVED, updatedAt: new Date() })
+      .where(eq(operatorSchema.operators.id, id))
+      .returning();
+
+    return updatedOperator[0];
+  }
   async rejectOperator(id: number, rejectionReason: string) {
     const operator = await this.db
       .select()


### PR DESCRIPTION
Add PATCH /admin/operators/:id/verify endpoint to allow admins to approve operators.

- Only admins can approve pending operators.
- Updates operator status to APPROVED.
- Returns updated operator data in AdminOperatorListDto format.
- Mirrors existing reject operator endpoint for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administrators can now verify pending operators using a new endpoint. The verification process updates operator status from pending to approved with proper role-based access control, ensuring only authorized admins can verify operators and access their details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->