### PR TITLE
add count operators for get admin operators

### DIFF
--- a/src/modules/operator/operator.service.spec.ts
+++ b/src/modules/operator/operator.service.spec.ts
@@ -195,16 +195,31 @@ describe('OperatorService', () => {
   });
 
   describe('getAllOperators', () => {
-    it('should get all operators', async () => {
+    it('should get all operators with meta', async () => {
       const operators = [mockOperator];
-      (mockDb.select as jest.Mock).mockReturnValue({
-        from: jest.fn().mockReturnThis(),
-        where: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        offset: jest.fn().mockResolvedValue(operators),
-      });
+
+      (mockDb.select as jest.Mock)
+        .mockReturnValueOnce({
+          from: jest.fn().mockReturnThis(),
+          where: jest.fn().mockResolvedValue([{ count: 1 }]),
+        })
+        .mockReturnValueOnce({
+          from: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          limit: jest.fn().mockReturnThis(),
+          offset: jest.fn().mockResolvedValue(operators),
+        });
+
       const result = await service.getAllOperators(10, 0);
-      expect(result).toEqual(operators);
+
+      expect(result).toEqual({
+        items: operators,
+        meta: {
+          total: 1,
+          limit: 10,
+          offset: 0,
+        },
+      });
     });
   });
 

--- a/src/modules/operator/operator.service.ts
+++ b/src/modules/operator/operator.service.ts
@@ -43,12 +43,28 @@ export class OperatorService {
     offset?: number,
     status?: OperatorStatus,
   ) {
-    return await this.db
+    const totalResult = await this.db
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(operatorSchema.operators)
+      .where(status ? eq(operatorSchema.operators.status, status) : undefined);
+
+    const total = Number(totalResult[0].count);
+
+    const items = await this.db
       .select()
       .from(operatorSchema.operators)
       .where(status ? eq(operatorSchema.operators.status, status) : undefined)
       .limit(limit)
       .offset(offset);
+
+    return {
+      items,
+      meta: {
+        total,
+        limit,
+        offset,
+      },
+    };
   }
 
   async updateOperatorStatus(


### PR DESCRIPTION
added meta to GET/admin/operators/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator query responses now return structured data with pagination metadata (total record count, limit, offset) alongside results for improved pagination and data handling.

* **Tests**
  * Unit tests updated to expect and validate the new paginated response shape.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->