### PR TITLE
Restrict critical operator fields update based on status

### DIFF
--- a/src/modules/operator/dto/update-operator.dto.ts
+++ b/src/modules/operator/dto/update-operator.dto.ts
@@ -66,6 +66,7 @@ export class UpdateOperatorDto {
   @ValidateIf(
     (o: UpdateOperatorDto) => o.firstName !== undefined && o.firstName !== '',
   )
+  @IsOptional()
   @IsString()
   @Length(2, 50, {
     message: 'First name must be between 2 and 50 characters',
@@ -75,6 +76,7 @@ export class UpdateOperatorDto {
   })
   firstName?: string;
 
+  @IsOptional()
   @ValidateIf(
     (o: UpdateOperatorDto) => o.lastName !== undefined && o.lastName !== '',
   )

--- a/src/modules/operator/operator.controller.ts
+++ b/src/modules/operator/operator.controller.ts
@@ -91,18 +91,61 @@ export class OperatorController {
     FileInterceptor('photo', { storage: multer.memoryStorage() }),
   )
   @ApiConsumes('multipart/form-data')
+  @ApiOperation({
+    summary: 'Update operator profile',
+    description: `
+  Rules:
+  - companyName, description, philosophy, photo can be updated anytime
+  - firstName, lastName, phone, website:
+    • can be updated ONLY when operator status is "rejected"
+    • after changing any of these fields, status is automatically set to "pending"
+    • cannot be updated when status is "pending" or "approved"
+  `,
+  })
   @ApiBody({
     schema: {
       type: 'object',
       properties: {
-        companyName: { type: 'string' },
-        description: { type: 'string' },
-        phone: { type: 'string' },
-        firstName: { type: 'string' },
-        lastName: { type: 'string' },
-        website: { type: 'string' },
-        philosophy: { type: 'string' },
-        photo: { type: 'string', format: 'binary', nullable: true },
+        companyName: {
+          type: 'string',
+          example: 'Travel Dreams LLC',
+        },
+        description: {
+          type: 'string',
+          example: 'We organize unforgettable tours across Europe',
+        },
+        philosophy: {
+          type: 'string',
+          example: 'Honesty, comfort and unforgettable memories',
+        },
+
+        firstName: {
+          type: 'string',
+          example: 'Ivan',
+          description: 'Allowed only when status is "rejected"',
+        },
+        lastName: {
+          type: 'string',
+          example: 'Ivanov',
+          description: 'Allowed only when status is "rejected"',
+        },
+        phone: {
+          type: 'string',
+          example: '+380501234567',
+          description: 'Allowed only when status is "rejected"',
+        },
+        website: {
+          type: 'string',
+          example: 'https://example.com',
+          description: 'Allowed only when status is "rejected"',
+        },
+
+        photo: {
+          type: 'string',
+          format: 'binary',
+          nullable: true,
+          description: 'Operator photo (JPEG/PNG/WEBP, max 5MB)',
+        },
       },
     },
   })

--- a/src/modules/operator/operator.service.ts
+++ b/src/modules/operator/operator.service.ts
@@ -141,22 +141,6 @@ export class OperatorService {
     req: AuthenticatedRequest,
     file?: Buffer,
   ) {
-    const updateData: Partial<typeof operatorSchema.operators.$inferInsert> =
-      {};
-
-    if (dto.companyName !== undefined) updateData.companyName = dto.companyName;
-    if (dto.description !== undefined) updateData.description = dto.description;
-    if (dto.firstName !== undefined) updateData.firstName = dto.firstName;
-    if (dto.lastName !== undefined) updateData.lastName = dto.lastName;
-    if (dto.phone !== undefined) updateData.phone = dto.phone;
-    if (dto.website !== undefined) updateData.website = dto.website;
-    if (dto.philosophy !== undefined) updateData.philosophy = dto.philosophy;
-
-    if (file) {
-      const photoUrl = (await this.cloudinaryService.uploadImage(file)).url;
-      updateData.photo = photoUrl;
-    }
-
     const operator = await this.db.query.operators.findFirst({
       where: eq(operatorSchema.operators.id, req.user.operatorId),
     });
@@ -165,13 +149,55 @@ export class OperatorService {
       throw new NotFoundException('Operator not found');
     }
 
+    const CRITICAL_FIELDS = [
+      'firstName',
+      'lastName',
+      'phone',
+      'website',
+    ] as const;
+
+    const criticalFieldsChanged = CRITICAL_FIELDS.some(
+      (field) => dto[field] !== undefined,
+    );
+
+    const operatorStatus = operator.status as OperatorStatus;
+
+    if (criticalFieldsChanged && operatorStatus !== OperatorStatus.REJECTED) {
+      throw new BadRequestException(
+        'firstName, lastName, phone, website can be changed only when operator status is rejected',
+      );
+    }
+
+    const updateData: Partial<typeof operatorSchema.operators.$inferInsert> =
+      {};
+
+    if (dto.companyName !== undefined) updateData.companyName = dto.companyName;
+    if (dto.description !== undefined) updateData.description = dto.description;
+    if (dto.philosophy !== undefined) updateData.philosophy = dto.philosophy;
+    if (dto.firstName !== undefined) updateData.firstName = dto.firstName;
+    if (dto.lastName !== undefined) updateData.lastName = dto.lastName;
+    if (dto.phone !== undefined) updateData.phone = dto.phone;
+    if (dto.website !== undefined) updateData.website = dto.website;
+
+    if (file) {
+      const photoUrl = (await this.cloudinaryService.uploadImage(file)).url;
+      updateData.photo = photoUrl;
+    }
+
+    if (criticalFieldsChanged) {
+      updateData.status = OperatorStatus.PENDING;
+      updateData.rejectionReason = null;
+    }
+
     if (!operator.email && req.user.email) {
       updateData.email = req.user.email;
     }
 
-    if (Object.keys(updateData).length > 0) {
-      updateData.updatedAt = new Date();
+    if (Object.keys(updateData).length === 0) {
+      return operator;
     }
+
+    updateData.updatedAt = new Date();
 
     const updatedOperator = await this.db
       .update(operatorSchema.operators)


### PR DESCRIPTION
- Updated PATCH /operator endpoint to enforce business rules:
  - firstName, lastName, phone, website can only be updated if operator status is REJECTED.
  - After updating any of these critical fields, status is automatically set to PENDING.
  - Other fields like companyName, description, philosophy, photo can be updated regardless of status.
- Added server-side validation to prevent unauthorized updates of verified data.
- Ensures consistency with admin verification workflow for operators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Operator profiles now support description and philosophy fields
  * First and last name are now optional fields in profile updates
  * Enhanced API documentation with detailed field examples and update guidelines

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->