### PR TITLE
Filter popular operators by active tours count

### DIFF
--- a/src/modules/operator/operator.controller.ts
+++ b/src/modules/operator/operator.controller.ts
@@ -174,10 +174,48 @@ export class OperatorController {
     return this.operatorService.getAllOperators(limit, offset, validStatus);
   }
   @Get('popular')
-  @ApiOperation({ summary: 'Отримати список популярних операторів' })
-  @ApiQuery({ name: 'limit', required: false, type: Number, example: 4 })
+  @ApiOperation({ summary: 'Get list of popular operators with active tours' })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+    example: 6,
+    description: 'Maximum number of operators to return',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of popular operators with at least one active tour',
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'number' },
+          email: { type: 'string' },
+          createdAt: { type: 'string', format: 'date-time' },
+          updatedAt: { type: 'string', format: 'date-time' },
+          userId: { type: 'number' },
+          companyName: { type: 'string' },
+          description: { type: 'string' },
+          firstName: { type: 'string' },
+          lastName: { type: 'string' },
+          website: { type: 'string' },
+          phone: { type: 'string' },
+          status: { type: 'string' },
+          philosophy: { type: 'string', nullable: true },
+          photo: { type: 'string', nullable: true },
+          bookingsCount: { type: 'number' },
+          activeToursCount: {
+            type: 'number',
+            description: 'Number of active tours for the operator',
+          },
+        },
+      },
+    },
+  })
   async getPopular(@Query() query: GetPopularOperatorsDto) {
-    return this.operatorService.getPopularOperators(query.limit);
+    const limit = query.limit ?? 6; // дефолтне значення
+    return this.operatorService.getPopularOperators(limit);
   }
   @Get(':id')
   getById(@Param('id', ParseIntPipe) id: number) {

--- a/src/modules/operator/operator.service.spec.ts
+++ b/src/modules/operator/operator.service.spec.ts
@@ -253,20 +253,23 @@ describe('OperatorService', () => {
   });
 
   describe('getPopularOperators', () => {
-    it('should get popular operators', async () => {
+    it('should get popular operators with active tours', async () => {
       const popularOperators = [
-        { ...mockOperator, bookingsCount: 10, toursCount: 5 },
+        { ...mockOperator, bookingsCount: 10, activeToursCount: 5 },
       ];
+
       (mockDb.select as jest.Mock).mockReturnValue({
         from: jest.fn().mockReturnThis(),
         leftJoin: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
+        having: jest.fn().mockReturnThis(), // Додаємо having
         orderBy: jest.fn().mockReturnThis(),
         limit: jest.fn().mockResolvedValue(popularOperators),
       });
 
       const result = await service.getPopularOperators(1);
       expect(result[0].bookingsCount).toBe(10);
+      expect(result[0].activeToursCount).toBe(5); // Перевіряємо нове поле
     });
   });
 });

--- a/src/modules/operator/operator.service.ts
+++ b/src/modules/operator/operator.service.ts
@@ -243,7 +243,7 @@ export class OperatorService {
   }
 
   async getPopularOperators(limit = 6) {
-    const operators = await this.db
+    const operatorsWithActiveTours = await this.db
       .select({
         id: operatorSchema.operators.id,
         email: operatorSchema.operators.email,
@@ -260,9 +260,7 @@ export class OperatorService {
         philosophy: operatorSchema.operators.philosophy,
         photo: operatorSchema.operators.photo,
         bookingsCount: sql<number>`COUNT(DISTINCT ${schema.bookings.id})`,
-        activeToursCount: sql<number>`
-          COUNT(DISTINCT CASE WHEN ${schema.tours.isActive} = true THEN ${schema.tours.id} END)
-        `,
+        activeToursCount: sql<number>`COUNT(DISTINCT CASE WHEN ${schema.tours.isActive} = true THEN ${schema.tours.id} END)`,
       })
       .from(operatorSchema.operators)
       .leftJoin(
@@ -277,7 +275,7 @@ export class OperatorService {
       .orderBy(sql`COUNT(DISTINCT ${schema.bookings.id}) DESC`)
       .limit(limit);
 
-    return operators.map((op) => ({
+    return operatorsWithActiveTours.map((op) => ({
       ...op,
       bookingsCount: Number(op.bookingsCount),
       activeToursCount: Number(op.activeToursCount),

--- a/src/modules/operator/operator.service.ts
+++ b/src/modules/operator/operator.service.ts
@@ -260,7 +260,9 @@ export class OperatorService {
         philosophy: operatorSchema.operators.philosophy,
         photo: operatorSchema.operators.photo,
         bookingsCount: sql<number>`COUNT(DISTINCT ${schema.bookings.id})`,
-        toursCount: sql<number>`COUNT(DISTINCT ${schema.tours.id})`,
+        activeToursCount: sql<number>`
+          COUNT(DISTINCT CASE WHEN ${schema.tours.isActive} = true THEN ${schema.tours.id} END)
+        `,
       })
       .from(operatorSchema.operators)
       .leftJoin(
@@ -269,13 +271,16 @@ export class OperatorService {
       )
       .leftJoin(schema.bookings, eq(schema.bookings.tourId, schema.tours.id))
       .groupBy(operatorSchema.operators.id)
+      .having(
+        sql`COUNT(DISTINCT CASE WHEN ${schema.tours.isActive} = true THEN ${schema.tours.id} END) > 0`,
+      )
       .orderBy(sql`COUNT(DISTINCT ${schema.bookings.id}) DESC`)
       .limit(limit);
 
     return operators.map((op) => ({
       ...op,
       bookingsCount: Number(op.bookingsCount),
-      toursCount: Number(op.toursCount),
+      activeToursCount: Number(op.activeToursCount),
     }));
   }
 }


### PR DESCRIPTION
Updated the "get popular operators" endpoint to return only operators with at least one active tour.  
Added `activeToursCount` to the response and updated Swagger documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Popular operators endpoint now defaults to 6 results when no limit is specified

* **Improvements**
  * Operators list now only includes those with active tours
  * Response includes activeToursCount for more accurate data
  * Enhanced API documentation with a more detailed response schema

* **Tests**
  * Updated tests to validate the activeToursCount field

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->