### PR TITLE
Filter popular operators by approved status

### DIFF
--- a/src/modules/operator/operator.service.spec.ts
+++ b/src/modules/operator/operator.service.spec.ts
@@ -253,23 +253,32 @@ describe('OperatorService', () => {
   });
 
   describe('getPopularOperators', () => {
-    it('should get popular operators with active tours', async () => {
+    it('should get popular approved operators ranked by active tours and bookings', async () => {
       const popularOperators = [
-        { ...mockOperator, bookingsCount: 10, activeToursCount: 5 },
+        {
+          ...mockOperator,
+          status: 'approved',
+          bookingsCount: 12,
+          activeToursCount: 6,
+        },
       ];
 
       (mockDb.select as jest.Mock).mockReturnValue({
         from: jest.fn().mockReturnThis(),
         leftJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
         groupBy: jest.fn().mockReturnThis(),
-        having: jest.fn().mockReturnThis(), // Додаємо having
+        having: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
         limit: jest.fn().mockResolvedValue(popularOperators),
       });
 
-      const result = await service.getPopularOperators(1);
-      expect(result[0].bookingsCount).toBe(10);
-      expect(result[0].activeToursCount).toBe(5); // Перевіряємо нове поле
+      const result = await service.getPopularOperators(4);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].status).toBe('approved');
+      expect(result[0].activeToursCount).toBe(6);
+      expect(result[0].bookingsCount).toBe(12);
     });
   });
 });

--- a/src/modules/operator/operator.service.ts
+++ b/src/modules/operator/operator.service.ts
@@ -268,7 +268,7 @@ export class OperatorService {
     return updatedOperator[0];
   }
 
-  async getPopularOperators(limit = 6) {
+  async getPopularOperators(limit = 4) {
     const operatorsWithActiveTours = await this.db
       .select({
         id: operatorSchema.operators.id,
@@ -285,20 +285,55 @@ export class OperatorService {
         status: operatorSchema.operators.status,
         philosophy: operatorSchema.operators.philosophy,
         photo: operatorSchema.operators.photo,
-        bookingsCount: sql<number>`COUNT(DISTINCT ${schema.bookings.id})`,
-        activeToursCount: sql<number>`COUNT(DISTINCT CASE WHEN ${schema.tours.isActive} = true THEN ${schema.tours.id} END)`,
+
+        bookingsCount: sql<number>`
+          COUNT(DISTINCT ${schema.bookings.id})
+        `,
+
+        activeToursCount: sql<number>`
+          COUNT(
+            DISTINCT CASE 
+            WHEN ${schema.tours.isActive} = true 
+            THEN ${schema.tours.id} 
+            END
+          )
+        `,
       })
       .from(operatorSchema.operators)
+
+      .where(eq(operatorSchema.operators.status, 'approved'))
+
       .leftJoin(
         schema.tours,
         eq(schema.tours.operatorId, operatorSchema.operators.id),
       )
       .leftJoin(schema.bookings, eq(schema.bookings.tourId, schema.tours.id))
+
       .groupBy(operatorSchema.operators.id)
+
       .having(
-        sql`COUNT(DISTINCT CASE WHEN ${schema.tours.isActive} = true THEN ${schema.tours.id} END) > 0`,
+        sql`
+          COUNT(
+            DISTINCT CASE 
+            WHEN ${schema.tours.isActive} = true 
+            THEN ${schema.tours.id} 
+            END
+          ) > 0
+        `,
       )
-      .orderBy(sql`COUNT(DISTINCT ${schema.bookings.id}) DESC`)
+
+      .orderBy(
+        sql`
+          COUNT(
+            DISTINCT CASE 
+            WHEN ${schema.tours.isActive} = true 
+            THEN ${schema.tours.id} 
+            END
+          ) DESC,
+          COUNT(DISTINCT ${schema.bookings.id}) DESC
+        `,
+      )
+
       .limit(limit);
 
     return operatorsWithActiveTours.map((op) => ({


### PR DESCRIPTION
Improved popular operators ranking logic.
Operators are now sorted by active tours count and bookings count.
Only approved operators with active tours are returned.
Limit is applied to return top operators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the popular operators ranking logic to prioritize operators with active tours and approved status.
  * Modified filtering to display only approved operators in popular operators results.
  * Adjusted the default retrieval limit for popular operators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->