### PR TITLE
realized two endpoint for user bookings

### DIFF
--- a/src/modules/bookings/bookings.module.ts
+++ b/src/modules/bookings/bookings.module.ts
@@ -8,6 +8,6 @@ import { UserModule } from '../user/user.module';
   imports: [forwardRef(() => UserModule)],
   controllers: [BookingsController],
   providers: [BookingsService, BookingGateway],
-  exports: [BookingGateway],
+  exports: [BookingsService, BookingGateway],
 })
 export class BookingsModule {}

--- a/src/modules/bookings/bookings.module.ts
+++ b/src/modules/bookings/bookings.module.ts
@@ -1,11 +1,11 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { BookingsService } from './bookings.service';
 import { BookingsController } from './bookings.controller';
 import { BookingGateway } from './booking.gateway';
 import { UserModule } from '../user/user.module';
 
 @Module({
-  imports: [UserModule],
+  imports: [forwardRef(() => UserModule)],
   controllers: [BookingsController],
   providers: [BookingsService, BookingGateway],
   exports: [BookingGateway],

--- a/src/modules/bookings/bookings.service.ts
+++ b/src/modules/bookings/bookings.service.ts
@@ -12,6 +12,7 @@ import Stripe from 'stripe';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { eq } from 'drizzle-orm';
 import { CreateBookingDto } from './dto/create-booking.dto';
+import { UserBookingMapper } from './mappers/user-booking.mapper';
 
 function isPgError(err: unknown): err is { cause: { code: string } } {
   return (
@@ -240,7 +241,6 @@ export class BookingsService {
       .from(bookings)
       .where(eq(bookings.tourId, tourId))
       .execute();
-    // result is an array with one object
     const stats = result[0] ?? { totalBookings: 0, totalPeople: 0 };
 
     if (Number(stats.totalBookings) === 0) {
@@ -249,13 +249,73 @@ export class BookingsService {
       );
     }
 
-    // Ensure numbers (sum may return string for bigint)
     return {
       totalBookings: Number(stats.totalBookings),
       totalPeople: Number(stats.totalPeople),
     };
   }
+  async getBookingsByUser(userId: number) {
+    const bookings = await this.db.query.bookings.findMany({
+      where: (b, { eq }) => eq(b.userId, userId),
+      with: { tour: true },
+      orderBy: (b, { desc }) => desc(b.createdAt),
+    });
 
+    // Для масиву викликаємо мапер напряму
+    return bookings.map((booking) => UserBookingMapper.toResponse(booking));
+  }
+
+  async getBookingByUser(userId: number, bookingId: number) {
+    const booking = await this.db.query.bookings.findFirst({
+      where: (b, { eq, and }) => and(eq(b.id, bookingId), eq(b.userId, userId)),
+      with: { tour: true },
+    });
+
+    if (!booking) {
+      throw new NotFoundException('Booking not found');
+    }
+
+    let paymentLink: string | null = null;
+
+    if (booking.status === 'pending_payment') {
+      if (booking.paymentProvider === 'stripe') {
+        const session = await this.stripe.checkout.sessions.create({
+          line_items: [
+            {
+              price_data: {
+                currency: booking.currency,
+                product_data: { name: booking.tour.title },
+                unit_amount: Math.round(Number(booking.totalPrice) * 100),
+              },
+              quantity: 1,
+            },
+          ],
+          mode: 'payment',
+          success_url: `${process.env.FRONTEND_URL}/catalog/tour/${booking.tourId}?success=true&bookingId=${booking.id}`,
+          cancel_url: `${process.env.FRONTEND_URL}/catalog/tour/${booking.tourId}?cancelled=true&bookingId=${booking.id}`,
+          metadata: { bookingId: booking.id.toString() },
+        });
+        paymentLink = session.url;
+      } else if (booking.paymentProvider === 'liqpay') {
+        const orderId = `booking_${booking.id}_${Date.now()}`;
+        const liqpayParams = {
+          action: 'pay',
+          amount: Number(booking.totalPrice).toFixed(2),
+          currency: booking.currency,
+          description: `Booking for tour ${booking.tour.title}`,
+          order_id: orderId,
+          server_url: `${process.env.API_URL}/payments/liqpay-webhook`,
+          result_url: `${process.env.FRONTEND_URL}/catalog/tour/${booking.tourId}?bookingId=${booking.id}`,
+          version: 3,
+          language: 'en',
+        };
+        paymentLink = this.liqpay.cnb_form(liqpayParams) ?? '';
+      }
+    }
+
+    // Один об’єкт — викликаємо мапер напряму
+    return UserBookingMapper.toResponse(booking, paymentLink);
+  }
   async getBookingWithTour(bookingId: number, tourId: number) {
     const booking = await this.db.query.bookings.findFirst({
       where: (bookings, { eq, and }) =>

--- a/src/modules/bookings/dto/user-booking-response.dto.ts
+++ b/src/modules/bookings/dto/user-booking-response.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+class TourShortDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  title: string;
+
+  @ApiProperty()
+  price: string;
+
+  @ApiProperty({ required: false })
+  coverImage?: string;
+}
+
+export class UserBookingResponseDto {
+  @ApiProperty()
+  bookingId: number;
+
+  @ApiProperty()
+  status: string;
+
+  @ApiProperty()
+  bookingPrice: string;
+
+  @ApiProperty()
+  currency: string;
+
+  @ApiProperty()
+  numberOfPeople: number;
+
+  @ApiProperty({ required: false })
+  firstPersonName?: string;
+
+  @ApiProperty({ required: false })
+  phone?: string;
+
+  @ApiProperty({ nullable: true })
+  paymentLink: string | null;
+
+  @ApiProperty()
+  tour: TourShortDto;
+}

--- a/src/modules/bookings/mappers/booking-with-tour.type.ts
+++ b/src/modules/bookings/mappers/booking-with-tour.type.ts
@@ -1,0 +1,9 @@
+import { InferSelectModel } from 'drizzle-orm';
+import { bookings } from '../bookings.schema';
+import { tours } from '@app/db/schema/schema';
+
+export type BookingWithTour = InferSelectModel<typeof bookings> & {
+  tour: InferSelectModel<typeof tours> & {
+    coverImage?: string | null; // поле стало опціональним
+  };
+};

--- a/src/modules/bookings/mappers/user-booking.mapper.ts
+++ b/src/modules/bookings/mappers/user-booking.mapper.ts
@@ -1,0 +1,22 @@
+import { BookingWithTour } from './booking-with-tour.type';
+
+export class UserBookingMapper {
+  static toResponse(booking: BookingWithTour, paymentLink?: string | null) {
+    return {
+      bookingId: booking.id,
+      status: booking.status,
+      bookingPrice: booking.totalPrice,
+      currency: booking.currency,
+      numberOfPeople: booking.numberOfPeople,
+      firstPersonName: booking.firstPersonName,
+      phone: booking.phone,
+      canRetryPayment: booking.status === 'pending_payment',
+      paymentLink: paymentLink ?? null,
+      tour: {
+        id: booking.tour.id,
+        title: booking.tour.title,
+        coverImage: booking.tour.coverImage ?? null,
+      },
+    };
+  }
+}

--- a/src/modules/payments/payments.module.ts
+++ b/src/modules/payments/payments.module.ts
@@ -1,11 +1,11 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { PaymentsService } from './payments.service';
 import { PaymentsController } from './payments.controller';
 import { BookingsModule } from '../bookings/bookings.module';
 import { EmailQueueModule } from '../email-queue/email-queue.module';
 
 @Module({
-  imports: [BookingsModule, EmailQueueModule],
+  imports: [forwardRef(() => BookingsModule), EmailQueueModule],
   controllers: [PaymentsController],
   providers: [PaymentsService],
 })

--- a/src/modules/payments/payments.module.ts
+++ b/src/modules/payments/payments.module.ts
@@ -8,5 +8,6 @@ import { EmailQueueModule } from '../email-queue/email-queue.module';
   imports: [forwardRef(() => BookingsModule), EmailQueueModule],
   controllers: [PaymentsController],
   providers: [PaymentsService],
+  exports: [PaymentsService],
 })
 export class PaymentsModule {}

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -48,7 +48,24 @@ export class PaymentsService {
       throw new BadRequestException('Booking is not in pending_payment status');
     }
 
-    const paymentLink = `https://checkout.stripe.com/pay/${booking.id}`;
+    const session = await this.stripe.checkout.sessions.create({
+      line_items: [
+        {
+          price_data: {
+            currency: booking.currency,
+            product_data: { name: `Retry payment for booking #${booking.id}` },
+            unit_amount: Math.round(Number(booking.totalPrice) * 100),
+          },
+          quantity: 1,
+        },
+      ],
+      mode: 'payment',
+      success_url: `${process.env.FRONTEND_URL}/catalog/tour/${booking.tourId}?success=true&bookingId=${booking.id}`,
+      cancel_url: `${process.env.FRONTEND_URL}/catalog/tour/${booking.tourId}?cancelled=true&bookingId=${booking.id}`,
+      metadata: { bookingId: booking.id.toString() },
+    });
+
+    const paymentLink = session.url ?? null;
 
     return { paymentLink };
   }

--- a/src/modules/payments/payments.service.ts
+++ b/src/modules/payments/payments.service.ts
@@ -35,7 +35,23 @@ export class PaymentsService {
       process.env.LIQPAY_PRIVATE_KEY,
     );
   }
+  async createPaymentForBooking(userId: number, bookingId: number) {
+    const booking = await this.db.query.bookings.findFirst({
+      where: (bookings, { eq }) => eq(bookings.id, bookingId),
+    });
 
+    if (!booking || booking.userId !== userId) {
+      throw new BadRequestException('Booking not found or access denied');
+    }
+
+    if (booking.status !== 'pending_payment') {
+      throw new BadRequestException('Booking is not in pending_payment status');
+    }
+
+    const paymentLink = `https://checkout.stripe.com/pay/${booking.id}`;
+
+    return { paymentLink };
+  }
   async handleStripeWebhook(req: RawBodyRequest<Request>, signature: string) {
     if (!process.env.STRIPE_WEBHOOK_SECRET) {
       throw new InternalServerErrorException(

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -2,6 +2,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
+import { BookingsService } from '@app/modules/bookings/bookings.service';
+import { PaymentsService } from '@app/modules/payments/payments.service';
 import { JwtAuthGuard } from '@app/common/guards/jwt-auth.guard';
 import { AuthenticatedRequest } from '@app/types/authenticated.request';
 import { UpdateUserInfoDto } from './dto/updateUserInfo.dto';
@@ -9,7 +11,7 @@ import { User } from './user.schema';
 
 describe('UserController', () => {
   let controller: UserController;
-  let service: UserService;
+  let userService: UserService;
 
   const mockUser: User = {
     id: 1,
@@ -31,6 +33,15 @@ describe('UserController', () => {
     getById: jest.fn(),
   };
 
+  const mockBookingsService = {
+    getBookingsByUser: jest.fn(),
+    getBookingByUser: jest.fn(),
+  };
+
+  const mockPaymentsService = {
+    createPaymentForBooking: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UserController],
@@ -39,6 +50,14 @@ describe('UserController', () => {
           provide: UserService,
           useValue: mockUserService,
         },
+        {
+          provide: BookingsService,
+          useValue: mockBookingsService,
+        },
+        {
+          provide: PaymentsService,
+          useValue: mockPaymentsService,
+        },
       ],
     })
       .overrideGuard(JwtAuthGuard)
@@ -46,7 +65,7 @@ describe('UserController', () => {
       .compile();
 
     controller = module.get<UserController>(UserController);
-    service = module.get<UserService>(UserService);
+    userService = module.get<UserService>(UserService);
   });
 
   it('should be defined', () => {
@@ -61,7 +80,7 @@ describe('UserController', () => {
       mockUserService.updateUser.mockResolvedValue(updatedUser);
 
       const result = await controller.updateUser(updateUserDto, req);
-      expect(service.updateUser).toHaveBeenCalledWith(1, updateUserDto);
+      expect(userService.updateUser).toHaveBeenCalledWith(1, updateUserDto);
       expect(result).toEqual(updatedUser);
     });
   });
@@ -72,7 +91,7 @@ describe('UserController', () => {
       mockUserService.getById.mockResolvedValue(mockUser);
 
       const result = await controller.getMe(req);
-      expect(service.getById).toHaveBeenCalledWith(1);
+      expect(userService.getById).toHaveBeenCalledWith(1);
       expect(result).toEqual(mockUser);
     });
   });

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -7,7 +7,7 @@ import {
   UseGuards,
   Param,
   Post,
-  BadRequestException,
+  ParseIntPipe,
 } from '@nestjs/common';
 import {
   ApiConsumes,
@@ -85,39 +85,30 @@ export class UserController {
     description: 'User booking details',
     type: UserBookingResponseDto,
   })
-  getUserBooking(@Param('id') id: string, @Req() req: AuthenticatedRequest) {
-    console.log('REQ.USER', req.user); // перевірка, чи є user
-    const bookingId = Number(id);
-    if (isNaN(bookingId)) throw new BadRequestException('Invalid booking ID');
+  getUserBooking(
+    @Param('id', ParseIntPipe) bookingId: number,
+    @Req() req: AuthenticatedRequest,
+  ) {
     return this.bookingsService.getBookingByUser(req.user.id, bookingId);
   }
-  @UseGuards(JwtAuthGuard)
+
   @Post('bookings/:id/retry-payment')
+  @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: 'Retry payment for pending booking' })
   @ApiResponse({
     status: 200,
     description: 'Returns payment link for retry',
-    schema: {
-      example: {
-        paymentLink: 'https://checkout.stripe.com/...',
-      },
-    },
+    schema: { example: { paymentLink: 'https://checkout.stripe.com/...' } },
   })
   @ApiResponse({
     status: 400,
     description: 'Booking is not in pending_payment status',
   })
-  @ApiResponse({
-    status: 404,
-    description: 'Booking not found',
-  })
+  @ApiResponse({ status: 404, description: 'Booking not found' })
   async retryBookingPayment(
-    @Param('id') bookingId: string,
+    @Param('id', ParseIntPipe) bookingId: number,
     @Req() req: AuthenticatedRequest,
   ) {
-    return this.paymentsService.createPaymentForBooking(
-      req.user.id,
-      Number(bookingId),
-    );
+    return this.paymentsService.createPaymentForBooking(req.user.id, bookingId);
   }
 }

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,16 +1,40 @@
-import { Body, Controller, Get, Patch, Req, UseGuards } from '@nestjs/common';
-import { ApiConsumes, ApiBody } from '@nestjs/swagger';
+import {
+  Body,
+  Controller,
+  Get,
+  Patch,
+  Req,
+  UseGuards,
+  Param,
+  Post,
+  BadRequestException,
+} from '@nestjs/common';
+import {
+  ApiConsumes,
+  ApiBody,
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '@app/common/guards/jwt-auth.guard';
 import { AuthenticatedRequest } from '@app/types/authenticated.request';
 import { UserService } from './user.service';
 import { UpdateUserInfoDto } from './dto/updateUserInfo.dto';
-
+import { BookingsService } from '@app/modules/bookings/bookings.service';
+import { UserBookingResponseDto } from '@app/modules/bookings/dto/user-booking-response.dto';
+import { PaymentsService } from '@app/modules/payments/payments.service';
+@ApiTags('User')
 @Controller('user')
 export class UserController {
-  constructor(private readonly usersService: UserService) {}
+  constructor(
+    private readonly usersService: UserService,
+    private readonly bookingsService: BookingsService,
+    private readonly paymentsService: PaymentsService,
+  ) {}
 
   @UseGuards(JwtAuthGuard)
   @Patch()
+  @ApiOperation({ summary: 'Update user profile info' })
   @ApiConsumes('application/json')
   @ApiBody({
     description: 'Update user info',
@@ -28,6 +52,7 @@ export class UserController {
       },
     },
   })
+  @ApiResponse({ status: 200, description: 'User updated successfully' })
   updateUser(
     @Body() updateUserInfoDto: UpdateUserInfoDto,
     @Req() req: AuthenticatedRequest,
@@ -37,24 +62,62 @@ export class UserController {
 
   @UseGuards(JwtAuthGuard)
   @Get('me')
-  @ApiBody({
-    description: 'Get user info',
-    examples: {
-      example1: {
-        summary: 'Example payload',
-        value: {
-          id: 1,
-          sub: 'auth0|1234567890',
-          firstPersonName: 'Іван',
-          firstPersonSurname: 'Іванов',
-          secondPersonName: 'Марія',
-          secondPersonSurname: 'Петренко',
-          email: 'example@gmail.com',
-        },
+  @ApiOperation({ summary: 'Get current user info (based on JWT)' })
+  @ApiResponse({ status: 200, description: 'Returns user entity' })
+  getMe(@Req() req: AuthenticatedRequest) {
+    return this.usersService.getById(req.user.id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiResponse({
+    status: 200,
+    description: 'List of user bookings',
+    type: [UserBookingResponseDto],
+  })
+  @Get('bookings')
+  getUserBookings(@Req() req: AuthenticatedRequest) {
+    return this.bookingsService.getBookingsByUser(req.user.id);
+  }
+  @Get('bookings/:id')
+  @UseGuards(JwtAuthGuard)
+  @ApiResponse({
+    status: 200,
+    description: 'User booking details',
+    type: UserBookingResponseDto,
+  })
+  getUserBooking(@Param('id') id: string, @Req() req: AuthenticatedRequest) {
+    console.log('REQ.USER', req.user); // перевірка, чи є user
+    const bookingId = Number(id);
+    if (isNaN(bookingId)) throw new BadRequestException('Invalid booking ID');
+    return this.bookingsService.getBookingByUser(req.user.id, bookingId);
+  }
+  @UseGuards(JwtAuthGuard)
+  @Post('bookings/:id/retry-payment')
+  @ApiOperation({ summary: 'Retry payment for pending booking' })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns payment link for retry',
+    schema: {
+      example: {
+        paymentLink: 'https://checkout.stripe.com/...',
       },
     },
   })
-  getMe(@Req() req: AuthenticatedRequest) {
-    return this.usersService.getById(req.user.id);
+  @ApiResponse({
+    status: 400,
+    description: 'Booking is not in pending_payment status',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Booking not found',
+  })
+  async retryBookingPayment(
+    @Param('id') bookingId: string,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.paymentsService.createPaymentForBooking(
+      req.user.id,
+      Number(bookingId),
+    );
   }
 }

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -1,8 +1,6 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
-import { BookingsService } from '@app/modules/bookings/bookings.service';
-import { PaymentsService } from '@app/modules/payments/payments.service';
 import { BookingsModule } from '../bookings/bookings.module';
 import { PaymentsModule } from '../payments/payments.module';
 import { EmailQueueModule } from '../email-queue/email-queue.module';
@@ -13,7 +11,7 @@ import { EmailQueueModule } from '../email-queue/email-queue.module';
     forwardRef(() => BookingsModule),
     EmailQueueModule,
   ],
-  providers: [UserService, BookingsService, PaymentsService],
+  providers: [UserService],
   controllers: [UserController],
   exports: [UserService],
 })

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -1,9 +1,19 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
+import { BookingsService } from '@app/modules/bookings/bookings.service';
+import { PaymentsService } from '@app/modules/payments/payments.service';
+import { BookingsModule } from '../bookings/bookings.module';
+import { PaymentsModule } from '../payments/payments.module';
+import { EmailQueueModule } from '../email-queue/email-queue.module';
 
 @Module({
-  providers: [UserService],
+  imports: [
+    forwardRef(() => PaymentsModule),
+    forwardRef(() => BookingsModule),
+    EmailQueueModule,
+  ],
+  providers: [UserService, BookingsService, PaymentsService],
   controllers: [UserController],
   exports: [UserService],
 })


### PR DESCRIPTION
Changes include:

GET /api/v1/user/bookings – Retrieve all bookings for the current authenticated user.

GET /api/v1/user/bookings/:id – Retrieve a specific booking for the current user by ID.

Additional Notes:

Endpoints are protected with JWT authentication.

Booking responses include related tour information, including optional coverImage.

Proper type support added for BookingWithTour to ensure API responses are correctly typed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can view their complete booking history with tour info.
  * Users can fetch detailed data for a specific booking (status, pricing, contact).
  * Users can retry failed or pending booking payments and receive a payment link.

* **Documentation**
  * API documentation for user and booking endpoints improved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->