### PR TITLE
add more information about operator to  user bookings

### DIFF
--- a/src/modules/bookings/bookings.service.ts
+++ b/src/modules/bookings/bookings.service.ts
@@ -221,17 +221,71 @@ export class BookingsService {
   async getBookingsByUser(userId: number) {
     const bookings = await this.db.query.bookings.findMany({
       where: (b, { eq }) => eq(b.userId, userId),
-      with: { tour: { with: { photos: true } } },
-      orderBy: (b, { desc }) => desc(b.createdAt),
+
+      with: {
+        tour: {
+          with: {
+            photos: true,
+            operator: {
+              columns: {
+                id: true,
+                firstName: true,
+                lastName: true,
+                photo: true,
+              },
+            },
+            city: {
+              with: {
+                translations: true,
+              },
+            },
+            country: {
+              with: {
+                translations: true,
+              },
+            },
+          },
+        },
+      },
+
+      orderBy: (b, { desc, sql }) => [
+        // pending_payment — першими
+        sql`CASE WHEN ${b.status} = 'pending_payment' THEN 0 ELSE 1 END`,
+        desc(b.createdAt),
+      ],
     });
 
     return bookings.map((booking) => UserBookingMapper.toResponse(booking));
   }
-
   async getBookingByUser(userId: number, bookingId: number) {
     const booking = await this.db.query.bookings.findFirst({
       where: (b, { eq, and }) => and(eq(b.id, bookingId), eq(b.userId, userId)),
-      with: { tour: { with: { photos: true } } },
+
+      with: {
+        tour: {
+          with: {
+            photos: true,
+            operator: {
+              columns: {
+                id: true,
+                firstName: true,
+                lastName: true,
+                photo: true,
+              },
+            },
+            city: {
+              with: {
+                translations: true,
+              },
+            },
+            country: {
+              with: {
+                translations: true,
+              },
+            },
+          },
+        },
+      },
     });
 
     if (!booking) {
@@ -258,26 +312,29 @@ export class BookingsService {
           cancel_url: `${process.env.FRONTEND_URL}/catalog/tour/${booking.tourId}?cancelled=true&bookingId=${booking.id}`,
           metadata: { bookingId: booking.id.toString() },
         });
+
         paymentLink = session.url;
       } else if (booking.paymentProvider === 'liqpay') {
         const orderId = `booking_${booking.id}_${Date.now()}`;
-        const liqpayParams = {
-          action: 'pay',
-          amount: Number(booking.totalPrice).toFixed(2),
-          currency: booking.currency,
-          description: `Booking for tour ${booking.tour.title}`,
-          order_id: orderId,
-          server_url: `${process.env.API_URL}/payments/liqpay-webhook`,
-          result_url: `${process.env.FRONTEND_URL}/catalog/tour/${booking.tourId}?bookingId=${booking.id}`,
-          version: 3,
-          language: 'en',
-        };
-        paymentLink = this.liqpay.cnb_form(liqpayParams) ?? '';
+
+        paymentLink =
+          this.liqpay.cnb_form({
+            action: 'pay',
+            amount: Number(booking.totalPrice).toFixed(2),
+            currency: booking.currency,
+            description: `Booking for tour ${booking.tour.title}`,
+            order_id: orderId,
+            server_url: `${process.env.API_URL}/payments/liqpay-webhook`,
+            result_url: `${process.env.FRONTEND_URL}/catalog/tour/${booking.tourId}?bookingId=${booking.id}`,
+            version: 3,
+            language: 'en',
+          }) ?? null;
       }
     }
 
     return UserBookingMapper.toResponse(booking, paymentLink);
   }
+
   async getBookingWithTour(bookingId: number, tourId: number) {
     const booking = await this.db.query.bookings.findFirst({
       where: (bookings, { eq, and, inArray }) =>

--- a/src/modules/bookings/dto/user-booking-response.dto.ts
+++ b/src/modules/bookings/dto/user-booking-response.dto.ts
@@ -14,6 +14,39 @@ class TourPhotoDto {
   description?: string;
 }
 
+/* 🔹 НОВЕ */
+class OperatorShortDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  firstName: string;
+
+  @ApiProperty()
+  lastName: string;
+
+  @ApiProperty({ nullable: true })
+  photo: string | null;
+}
+
+/* 🔹 НОВЕ */
+class CityShortDto {
+  @ApiProperty()
+  id: number;
+
+  @ApiProperty()
+  name: string;
+}
+
+/* 🔹 НОВЕ */
+class CountryShortDto {
+  @ApiProperty()
+  iso2: string;
+
+  @ApiProperty()
+  name: string;
+}
+
 class TourShortDto {
   @ApiProperty()
   id: number;
@@ -41,8 +74,10 @@ class TourShortDto {
 
   @ApiProperty()
   currency: string;
+
   @ApiProperty()
   startDate: string;
+
   @ApiProperty()
   endDate: string;
 
@@ -66,6 +101,16 @@ class TourShortDto {
 
   @ApiProperty({ type: [TourPhotoDto], required: false })
   photos?: TourPhotoDto[];
+
+  /* 🔥 ДОДАЛИ */
+  @ApiProperty({ nullable: true })
+  operator?: OperatorShortDto | null;
+
+  @ApiProperty({ nullable: true })
+  city?: CityShortDto | null;
+
+  @ApiProperty({ nullable: true })
+  country?: CountryShortDto | null;
 }
 
 export class UserBookingResponseDto {

--- a/src/modules/bookings/mappers/booking-with-tour.type.ts
+++ b/src/modules/bookings/mappers/booking-with-tour.type.ts
@@ -1,9 +1,34 @@
 import { InferSelectModel } from 'drizzle-orm';
-import { bookings } from '../bookings.schema';
-import { tours, tourPhotos } from '@app/db/schema/schema';
+import {
+  bookings,
+  tours,
+  tourPhotos,
+  operators,
+  cities,
+  countries,
+  cityTranslations,
+  countryTranslations,
+} from '@app/db/schema/schema';
 
 export type BookingWithTour = InferSelectModel<typeof bookings> & {
   tour: InferSelectModel<typeof tours> & {
     photos: InferSelectModel<typeof tourPhotos>[];
+
+    operator: Pick<
+      InferSelectModel<typeof operators>,
+      'id' | 'firstName' | 'lastName' | 'photo'
+    > | null;
+
+    city:
+      | (InferSelectModel<typeof cities> & {
+          translations: InferSelectModel<typeof cityTranslations>[];
+        })
+      | null;
+
+    country:
+      | (InferSelectModel<typeof countries> & {
+          translations: InferSelectModel<typeof countryTranslations>[];
+        })
+      | null;
   };
 };

--- a/src/modules/bookings/mappers/user-booking.mapper.ts
+++ b/src/modules/bookings/mappers/user-booking.mapper.ts
@@ -6,6 +6,9 @@ export class UserBookingMapper {
     booking: BookingWithTour,
     paymentLink?: string | null,
   ): UserBookingResponseDto {
+    const cityTranslation = booking.tour.city?.translations?.[0];
+    const countryTranslation = booking.tour.country?.translations?.[0];
+
     return {
       bookingId: booking.id,
       status: booking.status,
@@ -16,6 +19,7 @@ export class UserBookingMapper {
       phone: booking.phone,
       canRetryPayment: booking.status === 'pending_payment',
       paymentLink: paymentLink ?? null,
+
       tour: {
         id: booking.tour.id,
         operatorId: booking.tour.operatorId,
@@ -35,6 +39,29 @@ export class UserBookingMapper {
         createdAt: booking.tour.createdAt,
         updatedAt: booking.tour.updatedAt,
         photos: booking.tour.photos ?? [],
+
+        city: booking.tour.city
+          ? {
+              id: booking.tour.city.id,
+              name: cityTranslation?.name ?? null,
+            }
+          : null,
+
+        country: booking.tour.country
+          ? {
+              iso2: booking.tour.country.iso2,
+              name: countryTranslation?.name ?? null,
+            }
+          : null,
+
+        operator: booking.tour.operator
+          ? {
+              id: booking.tour.operator.id,
+              firstName: booking.tour.operator.firstName,
+              lastName: booking.tour.operator.lastName,
+              photo: booking.tour.operator.photo,
+            }
+          : null,
       },
     };
   }


### PR DESCRIPTION
Enhance /user/bookings response and improve sorting

Extended the /user/bookings and /user/bookings/:id endpoints to return additional tour-related data required by the frontend, including operator info (first name, last name, photo) and location details (city and country with translations).

Also improved sorting logic to ensure unpaid (pending_payment) bookings are shown first, with the most recent bookings appearing at the top.

No breaking changes to existing functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tour booking statistics retrieval functionality.
  * Enhanced booking details to display operator information, location details, and translations.

* **Improvements**
  * Optimized booking list sorting to prioritize pending payment status.
  * Updated payment link generation with improved integration handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->