### PR TITLE
Fix/endpoint operator bookings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,9 @@ lerna-debug.log*
 # pnpm store (якщо ще лишився)
 .pnpm-store/
 Dockerfile.dev
-
+# Node lock files
+package-lock.json
+pnpm-lock.yaml
 # Docker
 docker-compose.override.yml
 .docker/

--- a/src/modules/operator-bookings/operator-bookings.service.ts
+++ b/src/modules/operator-bookings/operator-bookings.service.ts
@@ -62,7 +62,10 @@ export class OperatorBookingsService {
       .from(bookings)
       .innerJoin(tours, eq(bookings.tourId, tours.id))
       .where(
-        and(inArray(bookings.tourId, tourIds), eq(bookings.status, 'paid')),
+        and(
+          inArray(bookings.tourId, tourIds),
+          eq(bookings.status, 'confirmed'),
+        ),
       );
 
     return result.map((b) => ({


### PR DESCRIPTION
Fix operator bookings endpoint to correctly return paid bookings.
Replaced incorrect `paid` booking status filter with `confirmed`,
which is the actual status used for successfully paid bookings.
As a result, confirmed (paid) tours now appear in the operator profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated operator bookings display to show confirmed bookings instead of paid bookings.

* **Chores**
  * Updated repository configuration to ignore Node package manager lock files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->