### PR TITLE
return only first names of the pair in customerName

### DIFF
--- a/src/modules/operator-bookings/operator-bookings.service.ts
+++ b/src/modules/operator-bookings/operator-bookings.service.ts
@@ -53,9 +53,7 @@ export class OperatorBookingsService {
         startDate: tours.startDate,
         endDate: tours.endDate,
         customerName: sql`
-        ${bookings.firstPersonName} || ' ' || ${bookings.firstPersonSurname} ||
-         ' та ' ||
-        ${bookings.secondPersonName} || ' ' || ${bookings.secondPersonSurname}
+        ${bookings.firstPersonName} || ' та ' || ${bookings.secondPersonName}
         `.as('customer_name'),
         customerPhone: bookings.phone,
       })


### PR DESCRIPTION
This update changes the `customerName` field in the operator bookings endpoint to include only the first names of the pair, removing surnames.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Simplified customer name display in operator bookings. Customer names now show first names only with streamlined formatting, removing surname information for a cleaner presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->