### PR TITLE
fixed pagination response for user bookings

### DIFF
--- a/src/modules/bookings/bookings.service.ts
+++ b/src/modules/bookings/bookings.service.ts
@@ -231,17 +231,27 @@ export class BookingsService {
       offset?: number;
     },
   ) {
-    const limit = query?.limit;
+    const limit = query?.limit ?? 10;
     const offset = query?.offset ?? 0;
 
-    const whereConditions = [eq(bookings.userId, userId)];
+    let statuses: string[] = ['confirmed', 'pending_payment'];
 
     if (query?.status) {
-      whereConditions.push(eq(bookings.status, query.status));
+      statuses = query.status.split(',').map((s) => s.trim());
     }
 
+    const whereCondition = and(
+      eq(bookings.userId, userId),
+      inArray(bookings.status, statuses),
+    );
+
+    const [{ total }] = await this.db
+      .select({ total: count() })
+      .from(bookings)
+      .where(whereCondition);
+
     const data = await this.db.query.bookings.findMany({
-      where: and(...whereConditions),
+      where: whereCondition,
       with: {
         tour: {
           with: {
@@ -263,11 +273,18 @@ export class BookingsService {
         sql`CASE WHEN ${b.status} = 'pending_payment' THEN 0 ELSE 1 END`,
         desc(b.createdAt),
       ],
-      limit: limit,
-      offset: offset || 0,
+      limit,
+      offset,
     });
 
-    return data.map((booking) => UserBookingMapper.toResponse(booking));
+    return {
+      data: data.map((booking) => UserBookingMapper.toResponse(booking)),
+      meta: {
+        total: Number(total),
+        limit,
+        offset,
+      },
+    };
   }
 
   async getBookingByUser(userId: number, bookingId: number) {

--- a/src/modules/bookings/dto/get-user-bookings.query.dto.ts
+++ b/src/modules/bookings/dto/get-user-bookings.query.dto.ts
@@ -4,8 +4,8 @@ import { Type } from 'class-transformer';
 
 export class GetUserBookingsQueryDto {
   @ApiPropertyOptional({
-    description: 'Filter by booking status',
-    example: 'pending_payment',
+    description: 'Filter by booking statuses (comma-separated)',
+    example: 'pending_payment,confirmed',
   })
   @IsOptional()
   @IsString()

--- a/src/modules/bookings/dto/pagination-meta.dto.ts
+++ b/src/modules/bookings/dto/pagination-meta.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PaginationMetaDto {
+  @ApiProperty({ example: 12 })
+  total: number;
+
+  @ApiProperty({ example: 6 })
+  limit: number;
+
+  @ApiProperty({ example: 0 })
+  offset: number;
+}

--- a/src/modules/bookings/dto/user-booking-response.dto.ts
+++ b/src/modules/bookings/dto/user-booking-response.dto.ts
@@ -99,7 +99,6 @@ class TourShortDto {
   @ApiProperty({ type: [TourPhotoDto], required: false })
   photos?: TourPhotoDto[];
 
-  /* 🔥 ДОДАЛИ */
   @ApiProperty({ nullable: true })
   operator?: OperatorShortDto | null;
 

--- a/src/modules/bookings/dto/user-bookings-paginated-response.dto.ts
+++ b/src/modules/bookings/dto/user-bookings-paginated-response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UserBookingResponseDto } from './user-booking-response.dto';
+import { PaginationMetaDto } from './pagination-meta.dto';
+
+export class UserBookingsPaginatedResponseDto {
+  @ApiProperty({ type: [UserBookingResponseDto] })
+  data: UserBookingResponseDto[];
+
+  @ApiProperty({ type: PaginationMetaDto })
+  meta: PaginationMetaDto;
+}

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -16,6 +16,7 @@ import {
   ApiTags,
   ApiOperation,
   ApiResponse,
+  ApiOkResponse,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '@app/common/guards/jwt-auth.guard';
 import { AuthenticatedRequest } from '@app/types/authenticated.request';
@@ -25,6 +26,7 @@ import { BookingsService } from '@app/modules/bookings/bookings.service';
 import { UserBookingResponseDto } from '@app/modules/bookings/dto/user-booking-response.dto';
 import { PaymentsService } from '@app/modules/payments/payments.service';
 import { GetUserBookingsQueryDto } from '@app/modules/bookings/dto/get-user-bookings.query.dto';
+import { UserBookingsPaginatedResponseDto } from '@app/modules/bookings/dto/user-bookings-paginated-response.dto';
 
 @ApiTags('User')
 @Controller('user')
@@ -73,6 +75,10 @@ export class UserController {
 
   @UseGuards(JwtAuthGuard)
   @Get('bookings')
+  @ApiOkResponse({
+    description: 'Paginated list of user bookings',
+    type: UserBookingsPaginatedResponseDto,
+  })
   getUserBookings(
     @Req() req: AuthenticatedRequest,
     @Query() query: GetUserBookingsQueryDto,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User bookings retrieval now supports filtering by multiple statuses simultaneously using comma-separated values
  * Pagination metadata added to booking responses, including total count and offset information
  * Default booking limit set to 10 when not specified

* **Documentation**
  * Enhanced API documentation for booking status filtering with updated examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->