### PR TITLE
Feature/operators change status email confirmation

### DIFF
--- a/drizzle/0027_polite_havok.sql
+++ b/drizzle/0027_polite_havok.sql
@@ -1,0 +1,3 @@
+CREATE TYPE "public"."operator_status" AS ENUM('pending', 'approved', 'rejected');--> statement-breakpoint
+ALTER TABLE "operators" ALTER COLUMN "status" SET DEFAULT 'pending'::"public"."operator_status";--> statement-breakpoint
+ALTER TABLE "operators" ALTER COLUMN "status" SET DATA TYPE "public"."operator_status" USING "status"::"public"."operator_status";

--- a/drizzle/meta/0027_snapshot.json
+++ b/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,947 @@
+{
+  "id": "cef6e243-dcb5-4e79-918d-e52ae5f0c77a",
+  "prevId": "2cbf8700-7de1-4b7a-a80b-9c061cf3c9dd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bookings": {
+      "name": "bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tour_id": {
+          "name": "tour_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_people": {
+          "name": "number_of_people",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "first_person_name": {
+          "name": "first_person_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_person_surname": {
+          "name": "first_person_surname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "second_person_name": {
+          "name": "second_person_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "second_person_surname": {
+          "name": "second_person_surname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_payment'"
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "payment_provider": {
+          "name": "payment_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_session_id": {
+          "name": "payment_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bookings_user_id_users_id_fk": {
+          "name": "bookings_user_id_users_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookings_tour_id_tours_id_fk": {
+          "name": "bookings_tour_id_tours_id_fk",
+          "tableFrom": "bookings",
+          "tableTo": "tours",
+          "columnsFrom": [
+            "tour_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cities": {
+      "name": "cities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "country_iso2": {
+          "name": "country_iso2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cities_country_iso2_countries_iso2_fk": {
+          "name": "cities_country_iso2_countries_iso2_fk",
+          "tableFrom": "cities",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_iso2"
+          ],
+          "columnsTo": [
+            "iso2"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.city_translations": {
+      "name": "city_translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "city_translations_city_id_cities_id_fk": {
+          "name": "city_translations_city_id_cities_id_fk",
+          "tableFrom": "city_translations",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "city_translations_city_id_language_code_unique": {
+          "name": "city_translations_city_id_language_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "city_id",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.countries": {
+      "name": "countries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iso2": {
+          "name": "iso2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iso3": {
+          "name": "iso3",
+          "type": "char(3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "countries_iso2_unique": {
+          "name": "countries_iso2_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iso2"
+          ]
+        },
+        "countries_iso3_unique": {
+          "name": "countries_iso3_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iso3"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.country_translations": {
+      "name": "country_translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "country_iso2": {
+          "name": "country_iso2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "country_translations_country_iso2_countries_iso2_fk": {
+          "name": "country_translations_country_iso2_countries_iso2_fk",
+          "tableFrom": "country_translations",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_iso2"
+          ],
+          "columnsTo": [
+            "iso2"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "country_translations_country_iso2_language_code_unique": {
+          "name": "country_translations_country_iso2_language_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "country_iso2",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health": {
+      "name": "health",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "health_email_unique": {
+          "name": "health_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "operator_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "philosophy": {
+          "name": "philosophy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo": {
+          "name": "photo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "operators_user_id_users_id_fk": {
+          "name": "operators_user_id_users_id_fk",
+          "tableFrom": "operators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "operators_email_unique": {
+          "name": "operators_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "operators_user_id_unique": {
+          "name": "operators_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tour_photos": {
+      "name": "tour_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tour_id": {
+          "name": "tour_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "main_photo_idx": {
+          "name": "main_photo_idx",
+          "columns": [
+            {
+              "expression": "tour_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"is_main\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tour_photos_tour_id_tours_id_fk": {
+          "name": "tour_photos_tour_id_tours_id_fk",
+          "tableFrom": "tour_photos",
+          "tableTo": "tours",
+          "columnsFrom": [
+            "tour_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tours": {
+      "name": "tours",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_iso2_code": {
+          "name": "country_iso2_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UAH'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available_spots": {
+          "name": "available_spots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "booked_spots": {
+          "name": "booked_spots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_spots": {
+          "name": "total_spots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "\"available_spots\" + COALESCE(\"booked_spots\", 0)",
+            "type": "stored"
+          }
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tours_operator_id_operators_id_fk": {
+          "name": "tours_operator_id_operators_id_fk",
+          "tableFrom": "tours",
+          "tableTo": "operators",
+          "columnsFrom": [
+            "operator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "tours_country_iso2_code_countries_iso2_fk": {
+          "name": "tours_country_iso2_code_countries_iso2_fk",
+          "tableFrom": "tours",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "country_iso2_code"
+          ],
+          "columnsTo": [
+            "iso2"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        },
+        "tours_city_id_cities_id_fk": {
+          "name": "tours_city_id_cities_id_fk",
+          "tableFrom": "tours",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "available_spots_check": {
+          "name": "available_spots_check",
+          "value": "\"available_spots\" >= 0 AND \"available_spots\" <= 100 AND \"available_spots\" % 2 = 0"
+        },
+        "price_check": {
+          "name": "price_check",
+          "value": "\"price\" >= 100 AND \"price\" <= 100000"
+        },
+        "currency_check": {
+          "name": "currency_check",
+          "value": "\"currency\" IN ('UAH', 'USD', 'EUR')"
+        },
+        "dates_check": {
+          "name": "dates_check",
+          "value": "\"start_date\" > current_date and \"end_date\" > \"start_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_person_name": {
+          "name": "first_person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_person_surname": {
+          "name": "first_person_surname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_person_name": {
+          "name": "second_person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_person_surname": {
+          "name": "second_person_surname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'traveler'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_sub_unique": {
+          "name": "users_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sub"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.operator_status": {
+      "name": "operator_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1766213104223,
       "tag": "0026_gifted_deathstrike",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1766916790729,
+      "tag": "0027_polite_havok",
+      "breakpoints": true
     }
   ]
 }

--- a/src/modules/admin/admin.module.ts
+++ b/src/modules/admin/admin.module.ts
@@ -3,9 +3,10 @@ import { AdminOperatorsController } from './admin-operators.controller';
 import { OperatorService } from '@app/modules/operator/operator.service';
 import { UserService } from '@app/modules/user/user.service';
 import { CloudinaryModule } from '@app/cloudinary/cloudinary.module';
+import { EmailQueueModule } from '../email-queue/email-queue.module';
 
 @Module({
-  imports: [CloudinaryModule],
+  imports: [CloudinaryModule, EmailQueueModule],
   controllers: [AdminOperatorsController],
   providers: [OperatorService, UserService],
 })

--- a/src/modules/email-queue/email-queue.processor.ts
+++ b/src/modules/email-queue/email-queue.processor.ts
@@ -212,6 +212,15 @@ export class EmailQueueProcessor extends WorkerHost {
     return `${localPart[0]}***@${domain}`;
   }
 
+  private escapeHtml(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
   private generateOperatorNewBookingText(data: OperatorEmailData): string {
     const { operatorName, bookingDetails } = data;
     return `
@@ -354,6 +363,7 @@ Booking CRM Team
     data: OperatorStatusChangeEmailData,
   ): string {
     const { operatorName, status, rejectionReason } = data;
+    const safeOperatorName = this.escapeHtml(operatorName);
     let message = `
 <!DOCTYPE html>
 <html>
@@ -364,15 +374,16 @@ Booking CRM Team
 <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
   <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
     <h2 style="color: ${status === 'approved' ? '#4CAF50' : '#F44336'};">Operator Status Updated</h2>
-    <p>Dear ${operatorName},</p>
+    <p>Dear ${safeOperatorName},</p>
     <p>Your operator status has been changed to <strong>${status.toUpperCase()}</strong>.</p>
 `;
 
     if (status === 'rejected' && rejectionReason) {
+      const safeRejectionReason = this.escapeHtml(rejectionReason);
       message += `
     <div style="background-color: #ffebee; padding: 15px; border-radius: 5px; margin: 15px 0; border-left: 5px solid #F44336;">
       <h3 style="color: #D32F2F; margin-top: 0;">Reason for rejection:</h3>
-      <p>${rejectionReason}</p>
+      <p>${safeRejectionReason}</p>
     </div>
 `;
     }

--- a/src/modules/email-queue/email-queue.processor.ts
+++ b/src/modules/email-queue/email-queue.processor.ts
@@ -5,6 +5,7 @@ import Mailjet from 'node-mailjet';
 import {
   BookingConfirmationEmailData,
   OperatorEmailData,
+  OperatorStatusChangeEmailData,
 } from './email-queue.service';
 
 @Processor('email')
@@ -21,7 +22,11 @@ export class EmailQueueProcessor extends WorkerHost {
   }
 
   async process(
-    job: Job<BookingConfirmationEmailData | OperatorEmailData>,
+    job: Job<
+      | BookingConfirmationEmailData
+      | OperatorEmailData
+      | OperatorStatusChangeEmailData
+    >,
   ): Promise<void> {
     this.logger.log(`Processing job ${job.id} of type ${job.name}`);
 
@@ -33,6 +38,10 @@ export class EmailQueueProcessor extends WorkerHost {
       await this.sendOperatorNewBookingEmail(job.data as OperatorEmailData);
     } else if (job.name === 'operator-booking-paid') {
       await this.sendOperatorBookingPaidEmail(job.data as OperatorEmailData);
+    } else if (job.name === 'operator-status-change') {
+      await this.sendOperatorStatusChangeEmail(
+        job.data as OperatorStatusChangeEmailData,
+      );
     }
   }
 
@@ -108,6 +117,45 @@ export class EmailQueueProcessor extends WorkerHost {
     } catch (error) {
       this.logger.error(
         `Failed to send operator booking paid email to ${this.maskEmail(email)}`,
+        error instanceof Error ? error.stack : JSON.stringify(error),
+      );
+      throw error;
+    }
+  }
+
+  private async sendOperatorStatusChangeEmail(
+    data: OperatorStatusChangeEmailData,
+  ): Promise<void> {
+    const { email, operatorName, status } = data;
+
+    try {
+      const request = this.mailjet.post('send', { version: 'v3.1' }).request({
+        Messages: [
+          {
+            From: {
+              Email: process.env.MAILJET_FROM_EMAIL || 'noreply@bookingcrm.com',
+              Name: process.env.MAILJET_FROM_NAME || 'Booking CRM',
+            },
+            To: [
+              {
+                Email: email,
+                Name: operatorName,
+              },
+            ],
+            Subject: `Operator Status Changed - ${status.toUpperCase()}`,
+            TextPart: this.generateOperatorStatusChangeText(data),
+            HTMLPart: this.generateOperatorStatusChangeHtml(data),
+          },
+        ],
+      });
+
+      await request;
+      this.logger.log(
+        `Operator status change email sent to ${this.maskEmail(email)}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to send operator status change email to ${this.maskEmail(email)}`,
         error instanceof Error ? error.stack : JSON.stringify(error),
       );
       throw error;
@@ -276,6 +324,66 @@ Booking CRM Team
 </body>
 </html>
     `.trim();
+  }
+
+  private generateOperatorStatusChangeText(
+    data: OperatorStatusChangeEmailData,
+  ): string {
+    const { operatorName, status, rejectionReason } = data;
+    let message = `
+Dear ${operatorName},
+
+Your operator status has been changed to ${status.toUpperCase()}.
+`;
+
+    if (status === 'rejected' && rejectionReason) {
+      message += `
+Reason for rejection:
+${rejectionReason}
+`;
+    }
+
+    message += `
+Best regards,
+Booking CRM Team
+`;
+    return message.trim();
+  }
+
+  private generateOperatorStatusChangeHtml(
+    data: OperatorStatusChangeEmailData,
+  ): string {
+    const { operatorName, status, rejectionReason } = data;
+    let message = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Operator Status Change</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+  <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+    <h2 style="color: ${status === 'approved' ? '#4CAF50' : '#F44336'};">Operator Status Updated</h2>
+    <p>Dear ${operatorName},</p>
+    <p>Your operator status has been changed to <strong>${status.toUpperCase()}</strong>.</p>
+`;
+
+    if (status === 'rejected' && rejectionReason) {
+      message += `
+    <div style="background-color: #ffebee; padding: 15px; border-radius: 5px; margin: 15px 0; border-left: 5px solid #F44336;">
+      <h3 style="color: #D32F2F; margin-top: 0;">Reason for rejection:</h3>
+      <p>${rejectionReason}</p>
+    </div>
+`;
+    }
+
+    message += `
+    <p>Best regards,<br>Booking CRM Team</p>
+  </div>
+</body>
+</html>
+`;
+    return message.trim();
   }
 
   private generateTextContent(

--- a/src/modules/email-queue/email-queue.service.ts
+++ b/src/modules/email-queue/email-queue.service.ts
@@ -33,6 +33,13 @@ export interface OperatorEmailData {
   };
 }
 
+export interface OperatorStatusChangeEmailData {
+  email: string;
+  operatorName: string;
+  status: string;
+  rejectionReason?: string;
+}
+
 @Injectable()
 export class EmailQueueService {
   constructor(@InjectQueue('email') private emailQueue: Queue) {}
@@ -59,6 +66,16 @@ export class EmailQueueService {
 
   async addOperatorBookingPaidEmail(data: OperatorEmailData) {
     await this.emailQueue.add('operator-booking-paid', data, {
+      attempts: 3,
+      backoff: {
+        type: 'exponential',
+        delay: 2000,
+      },
+    });
+  }
+
+  async addOperatorStatusChangeEmail(data: OperatorStatusChangeEmailData) {
+    await this.emailQueue.add('operator-status-change', data, {
       attempts: 3,
       backoff: {
         type: 'exponential',

--- a/src/modules/operator/operator.module.ts
+++ b/src/modules/operator/operator.module.ts
@@ -3,9 +3,10 @@ import { OperatorController } from './operator.controller';
 import { OperatorService } from './operator.service';
 import { UserService } from '../user/user.service';
 import { CloudinaryModule } from '@app/cloudinary/cloudinary.module';
+import { EmailQueueModule } from '../email-queue/email-queue.module';
 
 @Module({
-  imports: [CloudinaryModule],
+  imports: [CloudinaryModule, EmailQueueModule],
   controllers: [OperatorController],
   providers: [OperatorService, UserService],
 })

--- a/src/modules/operator/operator.schema.ts
+++ b/src/modules/operator/operator.schema.ts
@@ -1,5 +1,18 @@
 import { users } from '../user/user.schema';
-import { pgTable, serial, text, timestamp, integer } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  integer,
+  pgEnum,
+} from 'drizzle-orm/pg-core';
+
+export const operatorStatusEnum = pgEnum('operator_status', [
+  'pending',
+  'approved',
+  'rejected',
+]);
 
 export const operators = pgTable('operators', {
   id: serial('id').primaryKey(),
@@ -16,7 +29,7 @@ export const operators = pgTable('operators', {
   lastName: text('last_name').notNull(),
   website: text('website').notNull(),
   phone: text('phone').notNull(),
-  status: text('status').default('pending').notNull(),
+  status: operatorStatusEnum('status').default('pending').notNull(),
   philosophy: text('philosophy'),
   photo: text('photo'),
   rejectionReason: text('rejection_reason'),

--- a/src/modules/operator/operator.service.spec.ts
+++ b/src/modules/operator/operator.service.spec.ts
@@ -12,6 +12,7 @@ import { UserService } from '../user/user.service';
 import { OperatorService } from './operator.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { EmailQueueService } from '../email-queue/email-queue.service';
+import { OperatorStatus } from '@app/types/operator-status';
 /* eslint-disable @typescript-eslint/unbound-method */
 
 type Operator = typeof operators.$inferSelect;
@@ -152,6 +153,158 @@ describe('OperatorService', () => {
 
       const result = await service.updateOperator(updateOperatorDto, req);
       expect(result).toEqual(updatedOperator);
+    });
+  });
+
+  describe('updateOperatorStatus', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should throw NotFoundException if operator not found', async () => {
+      mockDb.query.operators.findFirst.mockResolvedValue(undefined);
+      await expect(
+        service.updateOperatorStatus(1, OperatorStatus.APPROVED),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException if rejection reason is too short', async () => {
+      mockDb.query.operators.findFirst.mockResolvedValue(mockOperator);
+      await expect(
+        service.updateOperatorStatus(1, OperatorStatus.REJECTED, 'Too short'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should update operator status to approved and send email notification', async () => {
+      const operatorWithEmail = { ...mockOperator, status: 'pending' };
+      const updatedOperator = { ...operatorWithEmail, status: 'approved' };
+
+      mockDb.query.operators.findFirst.mockResolvedValue(operatorWithEmail);
+      (mockDb.update as jest.Mock).mockReturnValue({
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        returning: jest.fn().mockResolvedValue([updatedOperator]),
+      });
+      mockEmailQueueService.addOperatorStatusChangeEmail.mockResolvedValue(
+        undefined,
+      );
+
+      const result = await service.updateOperatorStatus(
+        1,
+        OperatorStatus.APPROVED,
+      );
+
+      expect(result).toEqual(updatedOperator);
+      expect(
+        mockEmailQueueService.addOperatorStatusChangeEmail,
+      ).toHaveBeenCalledWith({
+        email: operatorWithEmail.email,
+        operatorName: `${operatorWithEmail.firstName} ${operatorWithEmail.lastName}`,
+        status: 'approved',
+        rejectionReason: undefined,
+      });
+      expect(
+        mockEmailQueueService.addOperatorStatusChangeEmail,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('should update operator status to rejected with reason and send email notification', async () => {
+      const operatorWithEmail = { ...mockOperator, status: 'pending' };
+      const rejectionReason =
+        'Your application does not meet our requirements because of insufficient documentation and experience.';
+      const updatedOperator = {
+        ...operatorWithEmail,
+        status: 'rejected',
+        rejectionReason,
+      };
+
+      mockDb.query.operators.findFirst.mockResolvedValue(operatorWithEmail);
+      (mockDb.update as jest.Mock).mockReturnValue({
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        returning: jest.fn().mockResolvedValue([updatedOperator]),
+      });
+      mockEmailQueueService.addOperatorStatusChangeEmail.mockResolvedValue(
+        undefined,
+      );
+
+      const result = await service.updateOperatorStatus(
+        1,
+        OperatorStatus.REJECTED,
+        rejectionReason,
+      );
+
+      expect(result).toEqual(updatedOperator);
+      expect(
+        mockEmailQueueService.addOperatorStatusChangeEmail,
+      ).toHaveBeenCalledWith({
+        email: operatorWithEmail.email,
+        operatorName: `${operatorWithEmail.firstName} ${operatorWithEmail.lastName}`,
+        status: 'rejected',
+        rejectionReason,
+      });
+      expect(
+        mockEmailQueueService.addOperatorStatusChangeEmail,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not send email notification if operator has no email', async () => {
+      const operatorWithoutEmail = { ...mockOperator, email: null };
+      const updatedOperator = { ...operatorWithoutEmail, status: 'approved' };
+
+      mockDb.query.operators.findFirst.mockResolvedValue(operatorWithoutEmail);
+      (mockDb.update as jest.Mock).mockReturnValue({
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        returning: jest.fn().mockResolvedValue([updatedOperator]),
+      });
+
+      const result = await service.updateOperatorStatus(
+        1,
+        OperatorStatus.APPROVED,
+      );
+
+      expect(result).toEqual(updatedOperator);
+      expect(
+        mockEmailQueueService.addOperatorStatusChangeEmail,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should update operator and send email even if status appears unchanged', async () => {
+      // Note: The service doesn't check if status changed, it always sends email
+      const operatorAlreadyApproved = { ...mockOperator, status: 'approved' };
+      const updatedOperator = {
+        ...operatorAlreadyApproved,
+        status: 'approved',
+      };
+
+      mockDb.query.operators.findFirst.mockResolvedValue(
+        operatorAlreadyApproved,
+      );
+      (mockDb.update as jest.Mock).mockReturnValue({
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        returning: jest.fn().mockResolvedValue([updatedOperator]),
+      });
+      mockEmailQueueService.addOperatorStatusChangeEmail.mockResolvedValue(
+        undefined,
+      );
+
+      const result = await service.updateOperatorStatus(
+        1,
+        OperatorStatus.APPROVED,
+      );
+
+      expect(result).toEqual(updatedOperator);
+      // Email is sent regardless of whether status actually changed
+      expect(
+        mockEmailQueueService.addOperatorStatusChangeEmail,
+      ).toHaveBeenCalledWith({
+        email: operatorAlreadyApproved.email,
+        operatorName: `${operatorAlreadyApproved.firstName} ${operatorAlreadyApproved.lastName}`,
+        status: 'approved',
+        rejectionReason: undefined,
+      });
     });
   });
 

--- a/src/modules/operator/operator.service.spec.ts
+++ b/src/modules/operator/operator.service.spec.ts
@@ -270,8 +270,8 @@ describe('OperatorService', () => {
       ).not.toHaveBeenCalled();
     });
 
-    it('should update operator and send email even if status appears unchanged', async () => {
-      // Note: The service doesn't check if status changed, it always sends email
+    it('should not send email notification if status has not changed', async () => {
+      // The service should only send email when the status actually changes
       const operatorAlreadyApproved = { ...mockOperator, status: 'approved' };
       const updatedOperator = {
         ...operatorAlreadyApproved,
@@ -296,15 +296,10 @@ describe('OperatorService', () => {
       );
 
       expect(result).toEqual(updatedOperator);
-      // Email is sent regardless of whether status actually changed
+      // Email should NOT be sent when status hasn't changed
       expect(
         mockEmailQueueService.addOperatorStatusChangeEmail,
-      ).toHaveBeenCalledWith({
-        email: operatorAlreadyApproved.email,
-        operatorName: `${operatorAlreadyApproved.firstName} ${operatorAlreadyApproved.lastName}`,
-        status: 'approved',
-        rejectionReason: undefined,
-      });
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/operator/operator.service.spec.ts
+++ b/src/modules/operator/operator.service.spec.ts
@@ -11,6 +11,7 @@ import { CloudinaryService } from '@app/cloudinary/cloudinary.service';
 import { UserService } from '../user/user.service';
 import { OperatorService } from './operator.service';
 import { Test, TestingModule } from '@nestjs/testing';
+import { EmailQueueService } from '../email-queue/email-queue.service';
 /* eslint-disable @typescript-eslint/unbound-method */
 
 type Operator = typeof operators.$inferSelect;
@@ -20,6 +21,7 @@ describe('OperatorService', () => {
   let mockDb: DeepMockProxy<NodePgDatabase<typeof schema>>;
   let mockUserService: DeepMockProxy<UserService>;
   let mockCloudinaryService: DeepMockProxy<CloudinaryService>;
+  let mockEmailQueueService: DeepMockProxy<EmailQueueService>;
 
   const mockUser: User = {
     id: 1,
@@ -58,6 +60,7 @@ describe('OperatorService', () => {
     mockDb = mockDeep<NodePgDatabase<typeof schema>>();
     mockUserService = mockDeep<UserService>();
     mockCloudinaryService = mockDeep<CloudinaryService>();
+    mockEmailQueueService = mockDeep<EmailQueueService>();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -65,6 +68,7 @@ describe('OperatorService', () => {
         { provide: 'DRIZZLE_CLIENT', useValue: mockDb },
         { provide: UserService, useValue: mockUserService },
         { provide: CloudinaryService, useValue: mockCloudinaryService },
+        { provide: EmailQueueService, useValue: mockEmailQueueService },
       ],
     }).compile();
 

--- a/src/modules/operator/operator.service.ts
+++ b/src/modules/operator/operator.service.ts
@@ -102,7 +102,7 @@ export class OperatorService {
       .where(eq(operators.id, id))
       .returning();
 
-    if (operator.email) {
+    if ((operator.status as OperatorStatus) !== status && operator.email) {
       await this.emailQueueService.addOperatorStatusChangeEmail({
         email: operator.email,
         operatorName: `${operator.firstName} ${operator.lastName}`,

--- a/src/modules/operator/operator.service.ts
+++ b/src/modules/operator/operator.service.ts
@@ -18,12 +18,15 @@ import { operators } from '@app/modules/operator/operator.schema';
 
 type OperatorSelect = typeof operators.$inferSelect;
 
+import { EmailQueueService } from '../email-queue/email-queue.service';
+
 @Injectable()
 export class OperatorService {
   constructor(
     @Inject('DRIZZLE_CLIENT') private db: NodePgDatabase<typeof schema>,
     private userService: UserService,
     private readonly cloudinaryService: CloudinaryService,
+    private readonly emailQueueService: EmailQueueService,
   ) {}
 
   async getOperatorByIdForAdmin(id: number): Promise<OperatorSelect> {
@@ -98,6 +101,15 @@ export class OperatorService {
       })
       .where(eq(operators.id, id))
       .returning();
+
+    if (operator.email) {
+      await this.emailQueueService.addOperatorStatusChangeEmail({
+        email: operator.email,
+        operatorName: `${operator.firstName} ${operator.lastName}`,
+        status,
+        rejectionReason,
+      });
+    }
 
     return updated[0];
   }


### PR DESCRIPTION
Feature/operators change status email confirmation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator status change email notifications added — operators receive automated HTML/text emails (including styled status indicators and rejection details) when their status changes; emails are enqueued with retries/backoff.
  * Status emails are triggered automatically when an operator has an email on file.

* **Tests**
  * Unit tests updated to cover status updates and the enqueueing/sending of operator status change notifications.

* **Chores**
  * Database schema updated to introduce an operator status enum with default "pending".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->