### PR TITLE
fix(operator): reject HTML tags in description field

### DIFF
--- a/src/modules/operator/dto/create-operator.dto.ts
+++ b/src/modules/operator/dto/create-operator.dto.ts
@@ -19,7 +19,9 @@ const WEBSITE_URL_PATTERN =
 const WEBSITE_URL_ERROR_MESSAGE =
   'Website must start with http:// or https://, contain a valid domain, and not include spaces';
 
-const COUNTRY_CODES = ['+380', '+1']; // список дозволених кодів країн
+const NO_HTML_PATTERN = /^[^<>]*$/;
+
+const COUNTRY_CODES = ['+380', '+1'];
 const COUNTRY_CODE_REGEX = COUNTRY_CODES.map((code) =>
   code.replace('+', '\\+'),
 ).join('|');
@@ -35,6 +37,9 @@ export class CreateOperatorDto {
   @IsString()
   @Length(10, 500, {
     message: 'Description must be between 10 and 500 characters',
+  })
+  @Matches(NO_HTML_PATTERN, {
+    message: 'HTML tags are not allowed in description',
   })
   description?: string;
 

--- a/src/modules/operator/dto/update-operator.dto.ts
+++ b/src/modules/operator/dto/update-operator.dto.ts
@@ -53,6 +53,9 @@ export class UpdateOperatorDto {
   @Length(10, 500, {
     message: 'Description must be between 10 and 500 characters',
   })
+  @Matches(NO_HTML_PATTERN, {
+    message: 'HTML tags are not allowed in description',
+  })
   description?: string;
 
   @IsOptional()


### PR DESCRIPTION
This PR fixes a validation issue where HTML tags were allowed in the operator
description field during create and update operations.

Added input validation to reject any HTML tags (e.g. <script>, <a>) in the
description field, preventing unsafe content from being stored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced validation to prevent HTML tags in operator descriptions when creating or updating operators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->