### PR TITLE
fix(validation): reject invalid percent-encoding in website URL

### DIFF
--- a/src/modules/operator/dto/create-operator.dto.ts
+++ b/src/modules/operator/dto/create-operator.dto.ts
@@ -14,7 +14,7 @@ const NAME_ERROR_MESSAGE =
   'must be 2–50 characters long, contain only letters (Latin or Cyrillic), single hyphens or apostrophes. ' +
   'Digits, spaces, special characters, consecutive or leading/trailing separators are not allowed.';
 const WEBSITE_URL_PATTERN =
-  /^(https?:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?::\d{1,5})?(\/[^\s]*)?$/;
+  /^(https?:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?::\d{1,5})?(\/(?:[A-Za-z0-9\-._~!$&'()*+,;=:@/]|%[0-9A-Fa-f]{2})*)?$/;
 
 const WEBSITE_URL_ERROR_MESSAGE =
   'Website must start with http:// or https://, contain a valid domain, and not include spaces';

--- a/src/modules/operator/dto/update-operator.dto.ts
+++ b/src/modules/operator/dto/update-operator.dto.ts
@@ -17,7 +17,7 @@ const NAME_ERROR_MESSAGE =
 
 const NO_HTML_PATTERN = /^[^<>]*$/;
 const WEBSITE_URL_PATTERN =
-  /^(https?:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?::\d{1,5})?(\/[^\s]*)?$/;
+  /^(https?:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?::\d{1,5})?(\/(?:[A-Za-z0-9\-._~!$&'()*+,;=:@/]|%[0-9A-Fa-f]{2})*)?$/;
 
 const WEBSITE_URL_ERROR_MESSAGE =
   'Website must start with http:// or https://, contain a valid domain, and not include spaces';


### PR DESCRIPTION
Fixed website URL validation to properly reject invalid percent-encoding
sequences (e.g. %ZZ). Updated URL regex to allow only valid hexadecimal
percent-encoded characters according to URL standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved website URL validation to accept a broader range of valid URLs, including those with additional path characters and percent-encoded segments, while maintaining protocol and domain validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->