### PR TITLE
fix: validate pagination query params in GET /admin/operators

### DIFF
--- a/src/modules/admin/admin-operators.controller.ts
+++ b/src/modules/admin/admin-operators.controller.ts
@@ -14,7 +14,6 @@ import {
   ApiOperation,
   ApiResponse,
   ApiTags,
-  ApiQuery,
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { OperatorService } from '@app/modules/operator/operator.service';
@@ -22,8 +21,7 @@ import { JwtAuthGuard } from '@app/common/guards/jwt-auth.guard';
 import { AdminOperatorFullDto } from './dto/admin-operator-full.dto';
 import { UpdateOperatorStatusDto } from './dto/update-operator-status.dto';
 import { Request } from 'express';
-import { OperatorStatus } from '@app/types/operator-status';
-
+import { GetOperatorsQueryDto } from './dto/get-operators.query.dto';
 @ApiTags('Admin')
 @ApiBearerAuth()
 @Controller('admin/operators')
@@ -33,14 +31,6 @@ export class AdminOperatorsController {
   // ================= GET ALL WITH FILTERS =================
   @UseGuards(JwtAuthGuard)
   @Get()
-  @ApiQuery({ name: 'limit', required: false, type: Number, example: 50 })
-  @ApiQuery({ name: 'offset', required: false, type: Number, example: 0 })
-  @ApiQuery({
-    name: 'status',
-    required: false,
-    enum: OperatorStatus,
-    description: 'pending | approved | rejected',
-  })
   @ApiOperation({ summary: 'Отримати всіх операторів з фільтром і пагінацією' })
   @ApiResponse({
     status: 200,
@@ -49,22 +39,15 @@ export class AdminOperatorsController {
   })
   async getOperators(
     @Req() req: Request & { user: { role: string } },
-    @Query('limit') limit?: string,
-    @Query('offset') offset?: string,
-    @Query('status') status?: OperatorStatus,
+    @Query() query: GetOperatorsQueryDto,
   ) {
     if (req.user?.role !== 'admin') {
       throw new ForbiddenException('Доступ дозволено лише адміністраторам');
     }
 
-    const limitNumber = limit ? Number(limit) : undefined;
-    const offsetNumber = offset ? Number(offset) : undefined;
+    const { limit, offset, status } = query;
 
-    return await this.operatorService.getAllOperators(
-      limitNumber,
-      offsetNumber,
-      status,
-    );
+    return await this.operatorService.getAllOperators(limit, offset, status);
   }
 
   // ================= GET ONE =================

--- a/src/modules/admin/dto/get-operators.query.dto.ts
+++ b/src/modules/admin/dto/get-operators.query.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEnum, IsInt, IsOptional, Min } from 'class-validator';
+import { IsEnum, IsInt, IsOptional, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
 import { OperatorStatus } from '@app/types/operator-status';
 
@@ -9,6 +9,7 @@ export class GetOperatorsQueryDto {
   @Type(() => Number)
   @IsInt({ message: 'limit must be an integer' })
   @Min(1, { message: 'limit must be greater than 0' })
+  @Max(100, { message: 'limit must be at most 100' })
   limit?: number;
 
   @ApiPropertyOptional({ example: 0 })
@@ -18,7 +19,10 @@ export class GetOperatorsQueryDto {
   @Min(0, { message: 'offset must be >= 0' })
   offset?: number;
 
-  @ApiPropertyOptional({ enum: OperatorStatus })
+  @ApiPropertyOptional({
+    enum: OperatorStatus,
+    description: 'pending | approved | rejected',
+  })
   @IsOptional()
   @IsEnum(OperatorStatus)
   status?: OperatorStatus;

--- a/src/modules/admin/dto/get-operators.query.dto.ts
+++ b/src/modules/admin/dto/get-operators.query.dto.ts
@@ -1,0 +1,25 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsInt, IsOptional, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { OperatorStatus } from '@app/types/operator-status';
+
+export class GetOperatorsQueryDto {
+  @ApiPropertyOptional({ example: 50 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'limit must be an integer' })
+  @Min(1, { message: 'limit must be greater than 0' })
+  limit?: number;
+
+  @ApiPropertyOptional({ example: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'offset must be an integer' })
+  @Min(0, { message: 'offset must be >= 0' })
+  offset?: number;
+
+  @ApiPropertyOptional({ enum: OperatorStatus })
+  @IsOptional()
+  @IsEnum(OperatorStatus)
+  status?: OperatorStatus;
+}

--- a/src/modules/operator/operator.service.ts
+++ b/src/modules/operator/operator.service.ts
@@ -46,6 +46,9 @@ export class OperatorService {
     offset?: number,
     status?: OperatorStatus,
   ) {
+    const safeLimit = limit ?? 50;
+    const safeOffset = offset ?? 0;
+
     const totalResult = await this.db
       .select({ count: sql<number>`COUNT(*)` })
       .from(operatorSchema.operators)
@@ -57,15 +60,15 @@ export class OperatorService {
       .select()
       .from(operatorSchema.operators)
       .where(status ? eq(operatorSchema.operators.status, status) : undefined)
-      .limit(limit)
-      .offset(offset);
+      .limit(safeLimit)
+      .offset(safeOffset);
 
     return {
       items,
       meta: {
         total,
-        limit,
-        offset,
+        limit: safeLimit,
+        offset: safeOffset,
       },
     };
   }


### PR DESCRIPTION
Add validation for pagination query parameters (limit, offset) in GET /admin/operators.
API now returns HTTP 400 for invalid values (negative numbers or non-numeric strings) instead of HTTP 200, with proper validation error messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated operator list query inputs into a single structured query, simplifying how requests are handled and validated.

* **New Features**
  * Query parameters (limit, offset, status) now enforce types, ranges, and enum validation to prevent invalid requests.
  * Default pagination values applied when limit/offset are omitted to ensure consistent paging and metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->