### PR TITLE
Bugfix/tour operator with status

### DIFF
--- a/src/modules/operator-bookings/operator-bookings.service.spec.ts
+++ b/src/modules/operator-bookings/operator-bookings.service.spec.ts
@@ -89,8 +89,24 @@ describe('OperatorBookingsService', () => {
       expect(result[0].bookingId).toBe(bookingsData[0].bookingId);
       expect(result[0].totalPriceUAH).toBe('4000.00'); // 100 * 40
     });
-  });
+    it('should throw ForbiddenException if operator status is "На перевірці"', async () => {
+      mockDb.where.mockResolvedValueOnce([
+        { operatorId: 1, status: 'На перевірці' },
+      ]);
+      await expect(service.getOperatorBookings(1)).rejects.toThrow(
+        'Доступ заборонено для вашого статусу оператора',
+      );
+    });
 
+    it('should throw ForbiddenException if operator status is "Відхилено"', async () => {
+      mockDb.where.mockResolvedValueOnce([
+        { operatorId: 1, status: 'Відхилено' },
+      ]);
+      await expect(service.getOperatorBookings(1)).rejects.toThrow(
+        'Доступ заборонено для вашого статусу оператора',
+      );
+    });
+  });
   describe('convertToUAH', () => {
     it('should convert USD to UAH', () => {
       // @ts-expect-error --- IGNORE --

--- a/src/modules/operator-bookings/operator-bookings.service.spec.ts
+++ b/src/modules/operator-bookings/operator-bookings.service.spec.ts
@@ -89,21 +89,21 @@ describe('OperatorBookingsService', () => {
       expect(result[0].bookingId).toBe(bookingsData[0].bookingId);
       expect(result[0].totalPriceUAH).toBe('4000.00'); // 100 * 40
     });
-    it('should throw ForbiddenException if operator status is "На перевірці"', async () => {
+    it('should throw ForbiddenException if operator status is pending', async () => {
       mockDb.where.mockResolvedValueOnce([
-        { operatorId: 1, status: 'На перевірці' },
+        { operatorId: 1, status: 'pending' },
       ]);
-      await expect(service.getOperatorBookings(1)).rejects.toThrow(
-        'Доступ заборонено для вашого статусу оператора',
+      await expect(service.getOperatorBookings(1)).rejects.toThrowError(
+        'Access denied',
       );
     });
 
-    it('should throw ForbiddenException if operator status is "Відхилено"', async () => {
+    it('should throw ForbiddenException if operator status is rejected', async () => {
       mockDb.where.mockResolvedValueOnce([
-        { operatorId: 1, status: 'Відхилено' },
+        { operatorId: 1, status: 'rejected' },
       ]);
-      await expect(service.getOperatorBookings(1)).rejects.toThrow(
-        'Доступ заборонено для вашого статусу оператора',
+      await expect(service.getOperatorBookings(1)).rejects.toThrowError(
+        'Access denied',
       );
     });
   });

--- a/src/modules/operator-bookings/operator-bookings.service.ts
+++ b/src/modules/operator-bookings/operator-bookings.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, ForbiddenException } from '@nestjs/common';
 import { eq, inArray, and, sql } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { bookings, tours, operators } from '@app/db/schema/schema';
@@ -27,12 +27,17 @@ export class OperatorBookingsService {
     if (!operatorUserId) return [];
 
     const [operator] = await this.db
-      .select({ operatorId: operators.id })
+      .select({ operatorId: operators.id, status: operators.status })
       .from(operators)
       .where(eq(operators.userId, operatorUserId));
 
     if (!operator) return [];
 
+    if (['На перевірці', 'Відхилено'].includes(operator.status)) {
+      throw new ForbiddenException(
+        'Доступ заборонено для вашого статусу оператора',
+      );
+    }
     const toursList = await this.db
       .select({ id: tours.id })
       .from(tours)

--- a/src/modules/operator-bookings/operator-bookings.service.ts
+++ b/src/modules/operator-bookings/operator-bookings.service.ts
@@ -33,9 +33,9 @@ export class OperatorBookingsService {
 
     if (!operator) return [];
 
-    if (['На перевірці', 'Відхилено'].includes(operator.status)) {
+    if (['pending', 'rejected'].includes(operator.status)) {
       throw new ForbiddenException(
-        'Доступ заборонено для вашого статусу оператора',
+        'Access denied: your operator status does not allow viewing bookings',
       );
     }
     const toursList = await this.db

--- a/src/modules/tours/dto/admin-get-tours-query.dto.ts
+++ b/src/modules/tours/dto/admin-get-tours-query.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsEnum, IsString } from 'class-validator';
+import { IsOptional, IsEnum, IsString, IsDateString } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { GetToursQueryDto } from './get-tours-query.dto';
 
@@ -18,12 +18,19 @@ export class AdminGetToursQueryDto extends GetToursQueryDto {
         return lower as TourStatus;
       }
     }
-    return undefined; // повертаємо undefined якщо value некоректне
+    return undefined;
   })
   status?: TourStatus;
 
   @IsOptional()
   @IsString()
   search?: string;
-  // limit/offset inherited from GetToursQueryDto
+
+  @IsOptional()
+  @IsDateString({}, { message: 'minDate must be a valid ISO date string' })
+  declare minDate?: string;
+
+  @IsOptional()
+  @IsDateString({}, { message: 'maxEndDate must be a valid ISO date string' })
+  declare maxEndDate?: string;
 }


### PR DESCRIPTION
 Added status check in OperatorBookingsService to forbid access for operators with status "Under Review" or "Rejected"
- Returns ForbiddenException (HTTP 403) instead of returning bookings
- Updated unit tests to cover restricted statuses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can filter tours by minimum start date and maximum end date (date-range filtering).

* **Bug Fixes**
  * Operators with "pending" or "rejected" status are prevented from accessing booking functionality.

* **Tests**
  * Added tests verifying access is denied for operators in "pending" and "rejected" statuses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->