### PR TITLE
fix(admin): validate feature update payload and return JSON 422

### DIFF
--- a/src/modules/tours/admin-tours.controller.ts
+++ b/src/modules/tours/admin-tours.controller.ts
@@ -10,6 +10,8 @@ import {
   ParseIntPipe,
   Req,
   ForbiddenException,
+  ValidationPipe,
+  UsePipes,
 } from '@nestjs/common';
 import { RolesGuard } from '../../common/guards/roles.guard';
 import { UpdateTourFeatureDto } from './dto/update-tour-feature.dto';
@@ -55,8 +57,15 @@ export class AdminToursController {
       },
     };
   }
-
   @Patch(':id/feature')
+  @UsePipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+      errorHttpStatusCode: 422, // або прибери — буде 400
+    }),
+  )
   async updateFeatureStatus(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateTourFeatureDto: UpdateTourFeatureDto,

--- a/src/modules/tours/dto/update-tour-feature.dto.ts
+++ b/src/modules/tours/dto/update-tour-feature.dto.ts
@@ -1,11 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsNotEmpty } from 'class-validator';
+import { IsBoolean, IsNotEmpty, IsDefined } from 'class-validator';
 
 export class UpdateTourFeatureDto {
   @ApiProperty({
     description: 'Status of the tour feature',
     example: true,
   })
+  @IsDefined()
   @IsBoolean()
   @IsNotEmpty()
   isFeatured: boolean;


### PR DESCRIPTION
is PR adds strict request body validation for the
PATCH /api/v1/admin/tours/:id/feature endpoint.
Previously, invalid or SQL-like payloads could bypass DTO validation and be blocked by the security layer (WAF), resulting in a 403 Forbidden response with an HTML body, breaking the API error contract.
Changes
Added ValidationPipe with whitelist and forbidNonWhitelisted to the feature update endpoint
Enforced strict DTO validation for isFeatured field
Ensured API returns a JSON validation error (400 / 422) instead of an HTML 403
Result
Invalid request payloads are rejected at the application level
API error responses are consistently returned in JSON format
API error contract is preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened validation for tour feature status updates with stricter data validation rules and improved error handling. Invalid requests now receive 422 status codes with clearer error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->