### PR TITLE
fix(bookings): validate limit, offset and status query params

### DIFF
--- a/src/modules/user/dto/get-user-bookings.query.dto.ts
+++ b/src/modules/user/dto/get-user-bookings.query.dto.ts
@@ -1,0 +1,28 @@
+import { IsOptional, IsInt, Min, Max, IsEnum } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export enum BookingStatus {
+  pending_payment = 'pending_payment',
+  paid = 'paid',
+  cancelled = 'cancelled',
+}
+
+export class GetUserBookingsQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 10;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  @Max(10000)
+  offset?: number = 0;
+
+  @IsOptional()
+  @IsEnum(BookingStatus)
+  status?: BookingStatus;
+}

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -9,6 +9,8 @@ import {
   Post,
   ParseIntPipe,
   Query,
+  ValidationPipe,
+  UsePipes,
 } from '@nestjs/common';
 import {
   ApiConsumes,
@@ -75,6 +77,14 @@ export class UserController {
 
   @UseGuards(JwtAuthGuard)
   @Get('bookings')
+  @UsePipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+      errorHttpStatusCode: 400,
+    }),
+  )
   @ApiOkResponse({
     description: 'Paginated list of user bookings',
     type: UserBookingsPaginatedResponseDto,


### PR DESCRIPTION
Add strict validation for user bookings query parameters

Description

This PR introduces strict input validation for the
GET /api/v1/user/bookings endpoint to ensure consistent API behavior and prevent unbounded or invalid requests.

Previously, excessive pagination values or invalid query parameters could result in HTTP 200 responses with empty datasets, or be blocked by the security layer, causing non-JSON error responses.

Changes

Added DTO-based validation for query parameters:

Enforced maximum allowed values for limit

Restricted offset to a realistic upper bound

Validated status against a predefined enum

Enabled request validation using ValidationPipe with transformation and whitelisting

Result

Excessive limit values are rejected with a validation error

Unrealistic offset values no longer return HTTP 200

Invalid status values are properly validated

All invalid inputs reaching the application return structured JSON errors (400 / 422)

Existing business logic and service behavior remain unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now filter their bookings by status (pending payment, paid, or cancelled).
  * Added pagination support for browsing bookings with customizable limit (1-100, default 10) and offset parameters.
  * Enhanced input validation for booking query parameters to ensure data integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->