### PR TITLE
fix(operator): enforce max limit on popular operators endpoint

### DIFF
--- a/src/modules/operator/dto/get-popular-operators.dto.ts
+++ b/src/modules/operator/dto/get-popular-operators.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsOptional, Min } from 'class-validator';
+import { IsInt, IsOptional, Min, Max } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
@@ -11,5 +11,6 @@ export class GetPopularOperatorsDto {
   @Type(() => Number)
   @IsInt()
   @Min(1)
+  @Max(100)
   limit?: number;
 }

--- a/src/modules/operator/operator.controller.ts
+++ b/src/modules/operator/operator.controller.ts
@@ -267,7 +267,14 @@ export class OperatorController {
     },
   })
   async getPopular(@Query() query: GetPopularOperatorsDto) {
-    const limit = query.limit ?? 6; // дефолтне значення
+    const DEFAULT_LIMIT = 6;
+    const MAX_LIMIT = 100;
+
+    let limit = query.limit ?? DEFAULT_LIMIT;
+    if (limit > MAX_LIMIT) {
+      limit = MAX_LIMIT;
+    }
+
     return this.operatorService.getPopularOperators(limit);
   }
   @Get(':id')


### PR DESCRIPTION
Enforce a maximum limit on the /operator/popular endpoint to prevent unbounded queries.  
- Default limit remains 6  
- Maximum limit capped at 100  
- Prevents returning excessively large datasets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Popular operators queries now enforce a maximum limit validation of 100 results to prevent excessive data retrieval.
  * Default limit for popular operators queries configured to 6 results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->