### PR TITLE
fix: validate invalid date query params for admin tours

### DIFF
--- a/src/common/validators/is-valid-date.validator.ts
+++ b/src/common/validators/is-valid-date.validator.ts
@@ -1,0 +1,38 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
+} from 'class-validator';
+
+export function IsValidDate(
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  return function (object: object, propertyName: string | symbol) {
+    registerDecorator({
+      name: 'IsValidDate',
+      target: object.constructor,
+      propertyName: String(propertyName),
+      options: validationOptions,
+      validator: {
+        validate(value: string) {
+          if (typeof value !== 'string') return false;
+
+          // YYYY-MM-DD
+          if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+
+          const [y, m, d] = value.split('-').map(Number);
+          const date = new Date(value);
+          return (
+            !isNaN(date.getTime()) &&
+            date.getUTCFullYear() === y &&
+            date.getUTCMonth() + 1 === m &&
+            date.getUTCDate() === d
+          );
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} must be a valid calendar date (YYYY-MM-DD)`;
+        },
+      },
+    });
+  };
+}

--- a/src/modules/tours/admin-tours.controller.ts
+++ b/src/modules/tours/admin-tours.controller.ts
@@ -30,6 +30,14 @@ export class AdminToursController {
   private readonly MAX_LIMIT = 100;
 
   @Get()
+  @UsePipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      errorHttpStatusCode: 400,
+    }),
+  )
   async findAll(
     @Req() req: Request & { user: { role: string } },
     @Query() query: AdminGetToursQueryDto,

--- a/src/modules/tours/dto/admin-get-tours-query.dto.ts
+++ b/src/modules/tours/dto/admin-get-tours-query.dto.ts
@@ -1,6 +1,7 @@
-import { IsOptional, IsEnum, IsString, IsDateString } from 'class-validator';
+import { IsOptional, IsEnum, IsString } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { GetToursQueryDto } from './get-tours-query.dto';
+import { IsValidDate } from '@app/common/validators/is-valid-date.validator';
 
 export enum TourStatus {
   ACTIVE = 'active',
@@ -27,10 +28,14 @@ export class AdminGetToursQueryDto extends GetToursQueryDto {
   search?: string;
 
   @IsOptional()
-  @IsDateString({}, { message: 'minDate must be a valid ISO date string' })
+  @IsValidDate({
+    message: 'minDate must be a valid calendar date (YYYY-MM-DD)',
+  })
   declare minDate?: string;
 
   @IsOptional()
-  @IsDateString({}, { message: 'maxEndDate must be a valid ISO date string' })
+  @IsValidDate({
+    message: 'maxEndDate must be a valid calendar date (YYYY-MM-DD)',
+  })
   declare maxEndDate?: string;
 }


### PR DESCRIPTION
Added strict calendar date validation for admin tours query parameters.
Invalid dates like 2026-02-31 are now rejected at DTO level with 400 Bad Request,
preventing database errors and 500 responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced date input validation for the admin tours interface with stricter format enforcement
  * Improved error messages for invalid date entries to provide clearer user guidance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->