### PR TITLE
Fix expired tours not allowed for bookings

### DIFF
--- a/src/modules/bookings/bookings.service.spec.ts
+++ b/src/modules/bookings/bookings.service.spec.ts
@@ -3,7 +3,11 @@ import { BookingsService } from './bookings.service';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import * as schema from '@app/db/schema/schema';
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
-import { NotFoundException, ConflictException } from '@nestjs/common';
+import {
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
 import { EmailQueueService } from '../email-queue/email-queue.service';
 
 // Mock Stripe and LiqPay
@@ -228,6 +232,41 @@ describe('BookingsService', () => {
       expect(result.paymentLink).toBe('http://liqpay.com/pay');
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockDb.update).toHaveBeenCalled();
+    });
+  });
+
+  describe('createBooking', () => {
+    it('should throw BadRequestException if tour start date is in the past', async () => {
+      const userId = 1;
+      const tourId = 1;
+      const pastDate = new Date();
+      pastDate.setDate(pastDate.getDate() - 1); // Yesterday
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      mockDb.query.users.findFirst.mockResolvedValue({ id: userId } as any);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      mockDb.query.tours.findFirst.mockResolvedValue({
+        id: tourId,
+        startDate: pastDate,
+        endDate: pastDate,
+        availableSpots: 10,
+        price: '100',
+        currency: 'USD',
+        operator: { email: 'operator@example.com' },
+      } as any);
+
+      const createBookingDto = {
+        tourId,
+        numberOfPeople: 2,
+        firstPersonName: 'First',
+        firstPersonSurname: 'Last',
+        phone: '+1234567890',
+        paymentProvider: 'stripe',
+      };
+
+      await expect(
+        service.createBooking(createBookingDto as any, userId),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/src/modules/bookings/bookings.service.ts
+++ b/src/modules/bookings/bookings.service.ts
@@ -74,6 +74,12 @@ export class BookingsService {
       throw new NotFoundException(`Tour with id ${data.tourId} not found`);
     }
 
+    if (new Date(tour.startDate) < new Date()) {
+      throw new BadRequestException(
+        'Tour has already started or ended. Booking is not allowed.',
+      );
+    }
+
     if (
       data.numberOfPeople > 100 ||
       data.numberOfPeople < 2 ||


### PR DESCRIPTION
Fix expired tours not allowed for bookings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The booking system now validates tour dates and prevents users from booking tours that have already started. Booking attempts for past or ongoing tours are rejected with an appropriate error message.

* **Tests**
  * Added test coverage to ensure the system correctly handles booking attempts for tours with past start dates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->