### PR TITLE
Add error 400 when not enough available spots

### DIFF
--- a/src/modules/tours/tours.controller.spec.ts
+++ b/src/modules/tours/tours.controller.spec.ts
@@ -121,20 +121,16 @@ describe('ToursController', () => {
       expect(toursService.checkAvailability).toHaveBeenCalledWith(1, 5);
     });
 
-    it('should return isAvailable false when not enough spots', async () => {
+    it('should propagate BadRequestException when not enough spots', async () => {
       const checkAvailabilityDto = { tourId: 1, spots: 15 };
-      const expectedResult = {
-        tourId: 1,
-        requestedSpots: 15,
-        availableSpots: 10,
-        isAvailable: false,
-      };
 
-      mockToursService.checkAvailability.mockResolvedValue(expectedResult);
+      mockToursService.checkAvailability.mockRejectedValue(
+        new BadRequestException('Not enough available spots'),
+      );
 
-      const result = await controller.checkAvailability(checkAvailabilityDto);
-
-      expect(result.isAvailable).toBe(false);
+      await expect(
+        controller.checkAvailability(checkAvailabilityDto),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('should throw NotFoundException when tour does not exist', async () => {

--- a/src/modules/tours/tours.service.spec.ts
+++ b/src/modules/tours/tours.service.spec.ts
@@ -113,18 +113,16 @@ describe('ToursService', () => {
       expect(mockDb.query.tours.findFirst).toHaveBeenCalled();
     });
 
-    it('should return isAvailable false when not enough spots', async () => {
+    it('should throw BadRequestException when not enough spots', async () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       mockDb.query.tours.findFirst.mockResolvedValue(mockTour as any);
 
-      const result = await service.checkAvailability(1, 15);
-
-      expect(result).toEqual({
-        tourId: 1,
-        requestedSpots: 15,
-        availableSpots: 10,
-        isAvailable: false,
-      });
+      await expect(service.checkAvailability(1, 15)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.checkAvailability(1, 15)).rejects.toThrow(
+        'Not enough available spots',
+      );
     });
 
     it('should throw NotFoundException when tour does not exist', async () => {

--- a/src/modules/tours/tours.service.ts
+++ b/src/modules/tours/tours.service.ts
@@ -486,13 +486,15 @@ export class ToursService {
       throw new BadRequestException(`Tour with ID ${tourId} is not active.`);
     }
 
-    const isAvailable = tour.availableSpots >= spots;
+    if (tour.availableSpots < spots) {
+      throw new BadRequestException('Not enough available spots');
+    }
 
     return {
       tourId: tour.id,
       requestedSpots: spots,
       availableSpots: tour.availableSpots,
-      isAvailable,
+      isAvailable: true,
     };
   }
 


### PR DESCRIPTION
Add error 400 when not enough available spots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tour availability checks now properly reject requests when insufficient spots are available, instead of returning a result indicating unavailability. Requests with inadequate availability will now receive an explicit error response.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->