### PR TITLE
Allow update price for tour with bookings

### DIFF
--- a/src/modules/tours/tours.service.spec.ts
+++ b/src/modules/tours/tours.service.spec.ts
@@ -6,6 +6,7 @@ import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import * as schema from '@app/db/schema/schema';
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { GetToursQueryDto } from './dto/get-tours-query.dto';
+import { UpdateTourDto } from './dto/update-tour.dto';
 import { Tour } from './tours.types';
 
 describe('ToursService', () => {
@@ -274,6 +275,63 @@ describe('ToursService', () => {
       await service.findAll(query);
 
       expect(mockDb.query.tours.findMany).toHaveBeenCalled();
+    });
+  });
+
+  describe('update', () => {
+    it('should allow price update when bookings count > 0', async () => {
+      const updateTourDto = {
+        price: 200,
+      } as UpdateTourDto;
+
+      // Mock existing tour (first call for ownership check)
+      mockDb.query.tours.findFirst.mockResolvedValueOnce(mockTour as any);
+
+      // Mock updated tour (second call after update)
+      const mockUpdatedTourResult = { ...mockTour, price: '200.00' };
+      mockDb.query.tours.findFirst.mockResolvedValueOnce(
+        mockUpdatedTourResult as any,
+      );
+
+      // Mock bookings exist
+      mockDb.query.bookings.findMany.mockResolvedValue([{ id: 1 }] as any);
+
+      // Mock update result
+      const mockUpdatedTour = { ...mockTour, price: '200.00' };
+      const mockReturning = {
+        returning: jest.fn().mockResolvedValue([mockUpdatedTour] as any),
+      };
+      const mockWhere = {
+        where: jest.fn().mockReturnValue(mockReturning),
+      };
+      const mockSet = {
+        set: jest.fn().mockReturnValue(mockWhere),
+      };
+      (mockDb.update as jest.Mock).mockReturnValue(mockSet);
+
+      const result = await service.update(1, updateTourDto, 1);
+
+      expect(result.price).toBe(200);
+      expect(mockDb.update).toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when updating disallowed fields with bookings', async () => {
+      const updateTourDto = {
+        title: 'New Title', // disallowed
+      } as UpdateTourDto;
+
+      // Mock existing tour
+      mockDb.query.tours.findFirst.mockResolvedValue(mockTour as any);
+
+      // Mock bookings exist
+      mockDb.query.bookings.findMany.mockResolvedValue([{ id: 1 }] as any);
+
+      await expect(service.update(1, updateTourDto, 1)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.update(1, updateTourDto, 1)).rejects.toThrow(
+        'This tour has bookings. Only description and available spots can be updated.',
+      );
     });
   });
 

--- a/src/modules/tours/tours.service.ts
+++ b/src/modules/tours/tours.service.ts
@@ -521,6 +521,7 @@ export class ToursService {
           const allowedUpdates: (keyof UpdateTourDto)[] = [
             'description',
             'availableSpots',
+            'price',
           ];
           const requestedUpdates = Object.keys(tourData).filter(
             (key) => tourData[key] !== undefined,


### PR DESCRIPTION
Allow update price for tour with bookings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tours can now have their prices updated even when bookings exist. Field validation ensures other properties remain protected during updates.

* **Tests**
  * Added comprehensive test coverage for tour update scenarios, including price modifications and field validation rules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->