### PR TITLE
fix: Fix active tours logic for popular operators

### DIFF
--- a/src/modules/operator/operator.service.ts
+++ b/src/modules/operator/operator.service.ts
@@ -284,6 +284,11 @@ export class OperatorService {
   }
 
   async getPopularOperators(limit = 4) {
+    const activeTourCondition = sql`
+      ${schema.tours.isActive} = true
+      AND ${schema.tours.endDate} >= NOW()
+    `;
+
     const operatorsWithActiveTours = await this.db
       .select({
         id: operatorSchema.operators.id,
@@ -307,48 +312,42 @@ export class OperatorService {
 
         activeToursCount: sql<number>`
           COUNT(
-            DISTINCT CASE 
-            WHEN ${schema.tours.isActive} = true 
-            THEN ${schema.tours.id} 
+            DISTINCT CASE
+              WHEN ${activeTourCondition}
+              THEN ${schema.tours.id}
             END
           )
         `,
       })
       .from(operatorSchema.operators)
-
       .where(eq(operatorSchema.operators.status, 'approved'))
-
       .leftJoin(
         schema.tours,
         eq(schema.tours.operatorId, operatorSchema.operators.id),
       )
       .leftJoin(schema.bookings, eq(schema.bookings.tourId, schema.tours.id))
-
       .groupBy(operatorSchema.operators.id)
-
       .having(
         sql`
-          COUNT(
-            DISTINCT CASE 
-            WHEN ${schema.tours.isActive} = true 
-            THEN ${schema.tours.id} 
-            END
-          ) > 0
-        `,
+        COUNT(
+          DISTINCT CASE
+            WHEN ${activeTourCondition}
+            THEN ${schema.tours.id}
+          END
+        ) > 0
+      `,
       )
-
       .orderBy(
         sql`
-          COUNT(
-            DISTINCT CASE 
-            WHEN ${schema.tours.isActive} = true 
-            THEN ${schema.tours.id} 
-            END
-          ) DESC,
-          COUNT(DISTINCT ${schema.bookings.id}) DESC
-        `,
+        COUNT(
+          DISTINCT CASE
+            WHEN ${activeTourCondition}
+            THEN ${schema.tours.id}
+          END
+        ) DESC,
+        COUNT(DISTINCT ${schema.bookings.id}) DESC
+      `,
       )
-
       .limit(limit);
 
     return operatorsWithActiveTours.map((op) => ({


### PR DESCRIPTION
Updated the logic for determining active tours when calculating popular operators.
Finished tours (with endDate in the past) are now excluded from active tours count,
so only currently active tours affect operator popularity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal query logic for filtering active tours, improving code maintainability without affecting external functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->