### PR TITLE
fix(tours): validate admin tour date filters and use admin query DTO

### DIFF
--- a/src/modules/tours/dto/admin-get-tours-query.dto.ts
+++ b/src/modules/tours/dto/admin-get-tours-query.dto.ts
@@ -29,9 +29,9 @@ export class AdminGetToursQueryDto extends GetToursQueryDto {
 
   @IsOptional()
   @IsValidDate({
-    message: 'minDate must be a valid calendar date (YYYY-MM-DD)',
+    message: 'minEndDate must be a valid calendar date (YYYY-MM-DD)',
   })
-  declare minDate?: string;
+  declare minEndDate?: string;
 
   @IsOptional()
   @IsValidDate({

--- a/src/modules/tours/tours.controller.ts
+++ b/src/modules/tours/tours.controller.ts
@@ -23,7 +23,7 @@ import {
 import { ToursService } from './tours.service';
 import { CreateTourDto } from './dto/create-tour.dto';
 import { Tour } from './tours.types';
-import { GetToursQueryDto } from './dto/get-tours-query.dto';
+import { AdminGetToursQueryDto } from './dto/admin-get-tours-query.dto';
 import { FileInterceptor, FilesInterceptor } from '@nestjs/platform-express';
 import multer from 'multer';
 import { CloudinaryService } from '@app/cloudinary/cloudinary.service';
@@ -123,7 +123,7 @@ export class ToursController {
       forbidNonWhitelisted: true,
     }),
   )
-  async findAll(@Query() query: GetToursQueryDto) {
+  async findAll(@Query() query: AdminGetToursQueryDto) {
     try {
       const toursData = await this.toursService.findAll(query);
       return {

--- a/src/modules/tours/tours.service.ts
+++ b/src/modules/tours/tours.service.ts
@@ -713,7 +713,6 @@ export class ToursService {
   }
 
   async remove(id: number, operatorId: number) {
-    // 1. Перевіряємо, чи тур існує і чи належить він цьому оператору
     const existingTour = await this.db.query.tours.findFirst({
       where: and(
         eq(schema.tours.id, id),


### PR DESCRIPTION
Fixes an issue where invalid date query parameters could cause a server error.

- Switched tours listing endpoint to use AdminGetToursQueryDto
- Added strict calendar date validation for admin date filters
- Prevents invalid dates from reaching the service layer

Result: invalid date inputs now return 400 instead of 500.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the tours API query parameter from `minDate` to `minEndDate` for improved naming clarity. The validation requirements remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->